### PR TITLE
Add missing attribute to test's mock incomplete_repo.

### DIFF
--- a/sample/tests/test_validation.py
+++ b/sample/tests/test_validation.py
@@ -132,6 +132,7 @@ def test_validate_repository_protocol_non_callable_attribute() -> None:
     """
     incomplete_repo = MagicMock()
     incomplete_repo.process_payment = MagicMock()
+    incomplete_repo.refund_payment = MagicMock()
     incomplete_repo.get_payment = "not_a_function"  # Not callable
 
     # @runtime_checkable doesn't detect non-callable attributes


### PR DESCRIPTION
This test failed for me locally, and when I checked why, it was because the `incomplete_repo` is missing the `refund_payment` method of the protocol.

But that then leaves me wondering how it is passing on your machine, or what is different?

(tbh: a lot of these tests are good examples of what I *wouldn't* commit even though the llm generates them... this particular test is just testing a known limitation of isinstance for protocols right? Why? It just adds code to the repo without benefit, IMO.).

Ran individual test with:
```
pytest sample/tests/test_validation.py::test_validate_repository_protocol_non_callable_attribute
```

Without change:
```
$ pytest sample/tests/test_validation.py::test_validate_repository_protocol_non_callable_attribute
========================================== test session starts ==========================================
platform linux -- Python 3.12.3, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/michael/dev/gosource/plays_with_temporal
configfile: pytest.ini
plugins: asyncio-1.1.0, anyio-4.10.0, hypothesis-6.138.2, cov-6.2.1
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item

sample/tests/test_validation.py F                                                                 [100%]

=============================================== FAILURES ================================================
_______________________ test_validate_repository_protocol_non_callable_attribute ________________________

    def test_validate_repository_protocol_non_callable_attribute() -> None:
        """Test repository protocol validation with non-callable attribute

        Note: @runtime_checkable only checks attribute existence, not callability.
        This is a known limitation of Python's protocol system.
        """
        incomplete_repo = MagicMock()
        incomplete_repo.process_payment = MagicMock()
        incomplete_repo.get_payment = "not_a_function"  # Not callable

        # @runtime_checkable doesn't detect non-callable attributes
        # This is expected behaviour - isinstance() only checks attribute
        # existence
        if not isinstance(incomplete_repo, PaymentRepository):
>           raise RepositoryValidationError(
                "Repository does not implement PaymentRepository protocol"
            )
E           sample.validation.RepositoryValidationError: Repository does not implement PaymentRepository protocol

sample/tests/test_validation.py:141: RepositoryValidationError
======================================== short test summary info ========================================
FAILED sample/tests/test_validation.py::test_validate_repository_protocol_non_callable_attribute - sample.validation.RepositoryValidationError: Repository does not implement PaymentRepository protocol
=========================================== 1 failed in 0.55s ===========================================
```

With change:
```
$ pytest sample/tests/test_validation.py::test_validate_repository_protocol_non_callable_attribute
========================================== test session starts ==========================================
platform linux -- Python 3.12.3, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/michael/dev/gosource/plays_with_temporal
configfile: pytest.ini
plugins: asyncio-1.1.0, anyio-4.10.0, hypothesis-6.138.2, cov-6.2.1
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item

sample/tests/test_validation.py .                                                                 [100%]

=========================================== 1 passed in 0.47s ===========================================
```