### PR TITLE
Use a `temporal_repository` class decorator to avoid layer 2

### DIFF
--- a/README
+++ b/README
@@ -18,7 +18,7 @@ Architecture Roadmap
 
 Core Principle: Dependencies point inward. Always.
 
-    Domain (Pure) -> Use Cases (Orchestrate) -> Adapters (Translate) -> Frameworks (Contain)
+    Domain (Pure) <- Use Cases (Orchestrate) <- Adapters (Translate) <- Frameworks (Contain)
 
 Three-Layer Repository Pattern (mandatory for all data access):
 1. Pure Backend -> 2. Temporal Activity -> 3. Workflow Proxy
@@ -28,10 +28,10 @@ Workflow Determinism: Activities for I/O, workflows for logic. No exceptions.
 Reference Applications
 ----------------------
 
-sample/ - Order fulfillment system  
+sample/ - Order fulfillment system
 Complete saga pattern with payments, inventory, cancellation. Your architectural north star.
 
-cal/ - Calendar intelligence system  
+cal/ - Calendar intelligence system
 AI-powered calendar analysis with Google integration. Domain-specific patterns.
 
 Navigation Guide
@@ -43,21 +43,21 @@ Start Here:
 - fun-police/systemPatterns.org - Implementation rules
 
 Deep Dive:
-- fun-police/projectbrief.org - Requirements and boundaries  
+- fun-police/projectbrief.org - Requirements and boundaries
 - fun-police/techContext.org - Technology stack decisions
 - fun-police/methodology.org - Development workflow
 - fun-police/tasks.org - Current work (org-mode TODOs)
 
 Quality Gates:
 - make quality-fast - Pre-commit checks
-- make quality-full - Complete validation  
+- make quality-full - Complete validation
 - make test-e2e - End-to-end with Docker
 
 Testing Strategy
 ----------------
 
     Many unit tests (mocked repositories)
-    Some integration tests (real dependencies)  
+    Some integration tests (real dependencies)
     Few E2E tests (complete workflows)
 
 Development Rules

--- a/sample/repos/temporal/decorators.py
+++ b/sample/repos/temporal/decorators.py
@@ -1,14 +1,13 @@
 """
-Temporal decorators for automatically wrapping repository methods as
-activities.
+Temporal decorator for automatically wrapping repository methods as activities
 
-This module provides decorators that can automatically wrap repository methods
+This module provides a decorator that automatically wraps repository methods
 as Temporal activities, reducing boilerplate and ensuring consistent patterns.
 """
 
 import inspect
 import logging
-from typing import Any, Callable, Type, TypeVar
+from typing import Type, TypeVar
 
 from temporalio import activity
 
@@ -125,158 +124,3 @@ def temporal_repository(activity_prefix: str):
         return cls
 
     return decorator
-
-
-def temporal_activity(activity_name: str):
-    """
-    Method decorator that wraps a single method as a Temporal activity.
-
-    This is useful when you need more granular control over individual methods
-    or when the automatic class decorator doesn't meet your needs.
-
-    Args:
-        activity_name: Full activity name for this method
-
-    Returns:
-        The decorated method wrapped as a Temporal activity
-
-    Example:
-        class MyRepository:
-            @temporal_activity("sample.custom.activity.name")
-            async def my_method(self, arg: str) -> str:
-                return f"processed {arg}"
-    """
-
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-        logger.debug(
-            f"Wrapping method {func.__name__} as activity {activity_name}"
-        )
-        return activity.defn(name=activity_name)(func)
-
-    return decorator
-
-
-def create_temporal_wrapper(
-    base_class: Type[T], activity_prefix: str, wrapper_class_name: str = None
-) -> Type[T]:
-    """
-    Factory function that creates a Temporal wrapper class dynamically.
-
-    This is an alternative to the class decorator that creates a new class
-    rather than modifying an existing one. Useful when you want to keep
-    the original class unchanged.
-
-    Args:
-        base_class: The base repository class to wrap
-        activity_prefix: Prefix for activity names
-        wrapper_class_name: Name for the new class (defaults to
-        Temporal{BaseName})
-
-    Returns:
-        A new class that inherits from base_class with methods wrapped as
-        activities
-
-    Example:
-        from sample.repos.minio.payment import MinioPaymentRepository
-
-        TemporalPaymentRepo = create_temporal_wrapper(
-            MinioPaymentRepository,
-            "sample.order_fulfillment.payment_repo",
-            "OrderFulfillmentPaymentRepository"
-        )
-
-        # Use the dynamically created class
-        repo = TemporalPaymentRepo("localhost:9000")
-    """
-    if wrapper_class_name is None:
-        wrapper_class_name = f"Temporal{base_class.__name__}"
-
-    logger.debug(
-        f"Creating temporal wrapper {wrapper_class_name} "
-        + "for {base_class.__name__}"
-    )
-
-    # Dictionary to hold the wrapped methods for the new class
-    class_dict = {}
-    wrapped_methods = []
-
-    # Find all async methods in the base class to wrap
-    for name, method in inspect.getmembers(base_class):
-        if inspect.iscoroutinefunction(method) and not name.startswith("_"):
-            activity_name = f"{activity_prefix}.{name}"
-
-            # Create a wrapper function that calls the parent method
-            def create_method_wrapper(method_name: str, activity_name: str):
-                async def wrapper(self, *args, **kwargs):
-                    # Get the method from the parent class and call it
-                    parent_method = getattr(
-                        super(wrapper_class, self), method_name
-                    )
-                    return await parent_method(*args, **kwargs)
-
-                # Apply activity decorator and preserve metadata
-                wrapper.__name__ = method_name
-                wrapper.__qualname__ = f"{wrapper_class_name}.{method_name}"
-
-                return activity.defn(name=activity_name)(wrapper)
-
-            class_dict[name] = create_method_wrapper(name, activity_name)
-            wrapped_methods.append(name)
-
-    # Create the new class dynamically
-    wrapper_class = type(wrapper_class_name, (base_class,), class_dict)
-
-    logger.info(
-        f"Created temporal wrapper class {wrapper_class_name}",
-        extra={
-            "base_class": base_class.__name__,
-            "wrapped_methods": wrapped_methods,
-            "activity_prefix": activity_prefix,
-        },
-    )
-
-    return wrapper_class
-
-
-def get_temporal_activity_info(cls: Type) -> dict[str, str]:
-    """
-    Helper function to inspect a class and return information about its
-    Temporal activities.
-
-    Args:
-        cls: Class to inspect
-
-    Returns:
-        Dictionary mapping method names to their activity names
-
-    Example:
-        info = get_temporal_activity_info(OrderFulfillmentPaymentRepository)
-        # Returns:
-        # {
-        # 'process_payment':
-        # 'sample.order_fulfillment.payment_repo.process_payment',
-        # 'get_payment': 'sample.order_fulfillment.payment_repo.get_payment',
-        # 'refund_payment':
-        # 'sample.order_fulfillment.payment_repo.refund_payment'
-        # }
-    """
-    activity_info = {}
-
-    for name, method in inspect.getmembers(cls):
-        try:
-            # Check if the method has a __dict__ and contains the activity
-            # definition Note: The key is '__temporal_activity_definition'
-            # (single trailing underscore)
-            if (
-                hasattr(method, "__dict__")
-                and "__temporal_activity_definition" in method.__dict__
-            ):
-                activity_def = method.__dict__[
-                    "__temporal_activity_definition"
-                ]
-                activity_info[name] = activity_def.name
-        except (AttributeError, TypeError):
-            # Skip methods that don't have activity definitions
-            continue
-
-    return activity_info

--- a/sample/repos/temporal/decorators.py
+++ b/sample/repos/temporal/decorators.py
@@ -1,0 +1,282 @@
+"""
+Temporal decorators for automatically wrapping repository methods as
+activities.
+
+This module provides decorators that can automatically wrap repository methods
+as Temporal activities, reducing boilerplate and ensuring consistent patterns.
+"""
+
+import inspect
+import logging
+from typing import Any, Callable, Type, TypeVar
+
+from temporalio import activity
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+def temporal_repository(activity_prefix: str):
+    """
+    Class decorator that automatically wraps all async methods as Temporal
+    activities.
+
+    This decorator inspects the class and wraps all async methods (coroutine
+    functions) that don't start with underscore as Temporal activities. The
+    activity names are generated using the provided prefix and the method
+    name.
+
+    Args:
+        activity_prefix: Prefix for activity names (e.g.,
+        "sample.payment_repo.minio") Method names will be appended to create
+        full activity names like "sample.payment_repo.minio.process_payment"
+
+    Returns:
+        The decorated class with all async methods wrapped as Temporal
+        activities
+
+    Example:
+        @temporal_repository("sample.order_fulfillment.payment_repo")
+        class OrderFulfillmentPaymentRepository(MinioPaymentRepository):
+            pass
+
+        # This automatically creates activities for all async methods: -
+        # process_payment ->
+        # "sample.order_fulfillment.payment_repo.process_payment" -
+        #  get_payment
+        # -> "sample.order_fulfillment.payment_repo.get_payment" -
+        # refund_payment ->
+        # "sample.order_fulfillment.payment_repo.refund_payment"
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        logger.debug(
+            f"Applying temporal_repository decorator to {cls.__name__}"
+        )
+
+        # Track which methods we wrap for logging
+        wrapped_methods = []
+
+        # Look at all classes in the MRO to find async methods to wrap
+        async_methods_to_wrap = {}
+
+        for base_class in cls.__mro__:
+            # Skip object base class
+            if base_class is object:
+                continue
+
+            # Get methods defined in this class (not inherited ones we've
+            # already seen)
+            for name in base_class.__dict__:
+                if name in async_methods_to_wrap:
+                    continue  # Already found this method in a subclass
+
+                method = getattr(base_class, name)
+
+                # Only wrap async methods that don't start with underscore
+                if inspect.iscoroutinefunction(
+                    method
+                ) and not name.startswith("_"):
+                    async_methods_to_wrap[name] = method
+
+        # Now wrap all the async methods we found
+        for name, method in async_methods_to_wrap.items():
+            # Create activity name by combining prefix and method name
+            activity_name = f"{activity_prefix}.{name}"
+
+            logger.debug(
+                f"Wrapping method {name} as activity {activity_name}"
+            )
+
+            # Create a new method that calls the original to avoid decorator
+            # conflicts
+            def create_wrapper_method(original_method, method_name):
+                async def wrapper_method(self, *args, **kwargs):
+                    return await original_method(self, *args, **kwargs)
+
+                # Preserve method metadata
+                wrapper_method.__name__ = method_name
+                wrapper_method.__qualname__ = f"{cls.__name__}.{method_name}"
+                wrapper_method.__doc__ = original_method.__doc__
+                wrapper_method.__annotations__ = getattr(
+                    original_method, "__annotations__", {}
+                )
+
+                return wrapper_method
+
+            # Create the wrapper and apply activity decorator
+            wrapper_method = create_wrapper_method(method, name)
+            wrapped_method = activity.defn(name=activity_name)(wrapper_method)
+
+            # Replace the method on the class with the wrapped version
+            setattr(cls, name, wrapped_method)
+
+            wrapped_methods.append(name)
+
+        logger.info(
+            f"Temporal repository decorator applied to {cls.__name__}",
+            extra={
+                "wrapped_methods": wrapped_methods,
+                "activity_prefix": activity_prefix,
+            },
+        )
+
+        return cls
+
+    return decorator
+
+
+def temporal_activity(activity_name: str):
+    """
+    Method decorator that wraps a single method as a Temporal activity.
+
+    This is useful when you need more granular control over individual methods
+    or when the automatic class decorator doesn't meet your needs.
+
+    Args:
+        activity_name: Full activity name for this method
+
+    Returns:
+        The decorated method wrapped as a Temporal activity
+
+    Example:
+        class MyRepository:
+            @temporal_activity("sample.custom.activity.name")
+            async def my_method(self, arg: str) -> str:
+                return f"processed {arg}"
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        logger.debug(
+            f"Wrapping method {func.__name__} as activity {activity_name}"
+        )
+        return activity.defn(name=activity_name)(func)
+
+    return decorator
+
+
+def create_temporal_wrapper(
+    base_class: Type[T], activity_prefix: str, wrapper_class_name: str = None
+) -> Type[T]:
+    """
+    Factory function that creates a Temporal wrapper class dynamically.
+
+    This is an alternative to the class decorator that creates a new class
+    rather than modifying an existing one. Useful when you want to keep
+    the original class unchanged.
+
+    Args:
+        base_class: The base repository class to wrap
+        activity_prefix: Prefix for activity names
+        wrapper_class_name: Name for the new class (defaults to
+        Temporal{BaseName})
+
+    Returns:
+        A new class that inherits from base_class with methods wrapped as
+        activities
+
+    Example:
+        from sample.repos.minio.payment import MinioPaymentRepository
+
+        TemporalPaymentRepo = create_temporal_wrapper(
+            MinioPaymentRepository,
+            "sample.order_fulfillment.payment_repo",
+            "OrderFulfillmentPaymentRepository"
+        )
+
+        # Use the dynamically created class
+        repo = TemporalPaymentRepo("localhost:9000")
+    """
+    if wrapper_class_name is None:
+        wrapper_class_name = f"Temporal{base_class.__name__}"
+
+    logger.debug(
+        f"Creating temporal wrapper {wrapper_class_name} "
+        + "for {base_class.__name__}"
+    )
+
+    # Dictionary to hold the wrapped methods for the new class
+    class_dict = {}
+    wrapped_methods = []
+
+    # Find all async methods in the base class to wrap
+    for name, method in inspect.getmembers(base_class):
+        if inspect.iscoroutinefunction(method) and not name.startswith("_"):
+            activity_name = f"{activity_prefix}.{name}"
+
+            # Create a wrapper function that calls the parent method
+            def create_method_wrapper(method_name: str, activity_name: str):
+                async def wrapper(self, *args, **kwargs):
+                    # Get the method from the parent class and call it
+                    parent_method = getattr(
+                        super(wrapper_class, self), method_name
+                    )
+                    return await parent_method(*args, **kwargs)
+
+                # Apply activity decorator and preserve metadata
+                wrapper.__name__ = method_name
+                wrapper.__qualname__ = f"{wrapper_class_name}.{method_name}"
+
+                return activity.defn(name=activity_name)(wrapper)
+
+            class_dict[name] = create_method_wrapper(name, activity_name)
+            wrapped_methods.append(name)
+
+    # Create the new class dynamically
+    wrapper_class = type(wrapper_class_name, (base_class,), class_dict)
+
+    logger.info(
+        f"Created temporal wrapper class {wrapper_class_name}",
+        extra={
+            "base_class": base_class.__name__,
+            "wrapped_methods": wrapped_methods,
+            "activity_prefix": activity_prefix,
+        },
+    )
+
+    return wrapper_class
+
+
+def get_temporal_activity_info(cls: Type) -> dict[str, str]:
+    """
+    Helper function to inspect a class and return information about its
+    Temporal activities.
+
+    Args:
+        cls: Class to inspect
+
+    Returns:
+        Dictionary mapping method names to their activity names
+
+    Example:
+        info = get_temporal_activity_info(OrderFulfillmentPaymentRepository)
+        # Returns:
+        # {
+        # 'process_payment':
+        # 'sample.order_fulfillment.payment_repo.process_payment',
+        # 'get_payment': 'sample.order_fulfillment.payment_repo.get_payment',
+        # 'refund_payment':
+        # 'sample.order_fulfillment.payment_repo.refund_payment'
+        # }
+    """
+    activity_info = {}
+
+    for name, method in inspect.getmembers(cls):
+        try:
+            # Check if the method has a __dict__ and contains the activity
+            # definition Note: The key is '__temporal_activity_definition'
+            # (single trailing underscore)
+            if (
+                hasattr(method, "__dict__")
+                and "__temporal_activity_definition" in method.__dict__
+            ):
+                activity_def = method.__dict__[
+                    "__temporal_activity_definition"
+                ]
+                activity_info[name] = activity_def.name
+        except (AttributeError, TypeError):
+            # Skip methods that don't have activity definitions
+            continue
+
+    return activity_info

--- a/sample/repos/temporal/minio_payments.py
+++ b/sample/repos/temporal/minio_payments.py
@@ -9,11 +9,8 @@ No use case prefixes or implementation details are included in activity names,
 providing a clean separation of concerns.
 """
 
-import logging
 from sample.repos.minio.payment import MinioPaymentRepository
 from sample.repos.temporal.decorators import temporal_repository
-
-logger = logging.getLogger(__name__)
 
 
 @temporal_repository("sample.payment_repo")
@@ -38,29 +35,9 @@ class TemporalMinioPaymentRepository(MinioPaymentRepository):
     - Significant reduction in boilerplate code
     """
 
-    def __init__(self, endpoint: str):
-        """
-        Initialize the Temporal wrapper with Minio connection details.
-
-        Args:
-            endpoint: Minio endpoint URL (e.g., "localhost:9000")
-        """
-        super().__init__(endpoint)
-        logger.debug("Initialized TemporalMinioPaymentRepository")
-
-    # That's it! No method definitions needed.
-    # The @temporal_repository decorator automatically wraps all async methods
-    # from the parent MinioPaymentRepository class as Temporal activities:
-    #
-    # - async def process_payment(self, order: Order) -> PaymentOutcome
-    #   becomes activity "sample.payment_repo.process_payment"
-    #
-    # - async def get_payment(self, payment_id: str) -> Optional[Payment]
-    #   becomes activity "sample.payment_repo.get_payment"
-    #
-    # - async def refund_payment(self, args: RefundPaymentArgs) ->
-    # RefundPaymentOutcome becomes activity
-    # "sample.payment_repo.refund_payment"
-    #
-    # All methods maintain their original signatures and behavior while being
-    # wrapped as Temporal activities for use in workflows.
+    # That's it! The @temporal_repository decorator automatically wraps
+    # all async methods as Temporal activities:
+    # - process_payment -> "sample.payment_repo.process_payment"
+    # - get_payment -> "sample.payment_repo.get_payment"
+    # - refund_payment -> "sample.payment_repo.refund_payment"
+    pass

--- a/sample/repos/temporal/proxies/payment.py
+++ b/sample/repos/temporal/proxies/payment.py
@@ -54,7 +54,7 @@ class WorkflowPaymentRepositoryProxy(PaymentRepository):
         # might deserialize it as a dict in the workflow context.
         # Explicitly re-validate to ensure it's a Pydantic model.
         raw_result = await workflow.execute_activity(
-            "sample.order_fulfillment.payment_repo.minio.process_payment",
+            "sample.payment_repo.process_payment",
             order,
             start_to_close_timeout=self.activity_timeout,
             retry_policy=self.activity_fail_fast_retry_policy,
@@ -82,7 +82,7 @@ class WorkflowPaymentRepositoryProxy(PaymentRepository):
         # Temporal's data converter might deserialize it as a dict or None
         # in the workflow context. Explicitly re-validate if not None.
         raw_result = await workflow.execute_activity(
-            "sample.order_fulfillment.payment_repo.minio.get_payment",
+            "sample.payment_repo.get_payment",
             payment_id,
             start_to_close_timeout=self.activity_timeout,
         )
@@ -111,7 +111,7 @@ class WorkflowPaymentRepositoryProxy(PaymentRepository):
             extra={"payment_id": args.payment_id, "amount": str(args.amount)},
         )
         raw_result = await workflow.execute_activity(
-            "sample.cancel_order.payment_repo.minio.refund_payment",
+            "sample.payment_repo.refund_payment",
             args,
             start_to_close_timeout=self.activity_timeout,
             retry_policy=self.activity_fail_fast_retry_policy,

--- a/sample/tests/test_validation.py
+++ b/sample/tests/test_validation.py
@@ -16,7 +16,6 @@ from sample.validation import (
     ensure_payment_repository,
 )
 from sample.repositories import PaymentRepository, InventoryRepository
-from sample.repos.minio.payment import MinioPaymentRepository
 from sample.repos.minio.inventory import MinioInventoryRepository
 from sample.repos.temporal.minio_payments import (
     TemporalMinioPaymentRepository,
@@ -29,11 +28,8 @@ from sample.domain import Order, Payment, OrderItem
 
 def test_runtime_checkable_validation_success() -> None:
     """Test that @runtime_checkable validation works correctly"""
-    # Test with the Temporal Activity implementation using mocked dependencies
-    mock_minio_payment_repo = MagicMock(spec=MinioPaymentRepository)
-    repo = TemporalMinioPaymentRepository(
-        mock_minio_payment_repo
-    )  # Fixed: only pass payment repo
+    # Test with the Temporal Activity implementation
+    repo = TemporalMinioPaymentRepository("test-endpoint")
 
     # Should not raise
     assert isinstance(repo, PaymentRepository)
@@ -64,10 +60,7 @@ def test_runtime_checkable_validation_failure() -> None:
 
 def test_ensure_repository_provides_type_safety() -> None:
     """Test that ensure_* functions provide proper typing"""
-    mock_minio_payment_repo = MagicMock(spec=MinioPaymentRepository)
-    repo = TemporalMinioPaymentRepository(
-        mock_minio_payment_repo
-    )  # Fixed: only pass payment repo
+    repo = TemporalMinioPaymentRepository("test-endpoint")
 
     # This should pass both runtime and static type checking
     validated_repo = ensure_payment_repository(repo)
@@ -79,10 +72,7 @@ def test_ensure_repository_provides_type_safety() -> None:
 
 def test_isinstance_works_with_all_protocols() -> None:
     """Test isinstance works with all repository protocols"""
-    mock_minio_payment_repo = MagicMock(spec=MinioPaymentRepository)
-    payment_repo = TemporalMinioPaymentRepository(
-        mock_minio_payment_repo
-    )  # Fixed: only pass payment repo
+    payment_repo = TemporalMinioPaymentRepository("test-endpoint")
 
     mock_minio_inventory_repo = MagicMock(spec=MinioInventoryRepository)
     inventory_repo = TemporalMinioInventoryRepository(
@@ -99,10 +89,7 @@ def test_isinstance_works_with_all_protocols() -> None:
 
 def test_validate_repository_protocol_success() -> None:
     """Test successful repository protocol validation"""
-    mock_minio_payment_repo = MagicMock(spec=MinioPaymentRepository)
-    repo = TemporalMinioPaymentRepository(
-        mock_minio_payment_repo
-    )  # Fixed: only pass payment repo
+    repo = TemporalMinioPaymentRepository("test-endpoint")
 
     # Should not raise any exception - just verify it's a PaymentRepository
     assert isinstance(repo, PaymentRepository)
@@ -132,8 +119,8 @@ def test_validate_repository_protocol_non_callable_attribute() -> None:
     """
     incomplete_repo = MagicMock()
     incomplete_repo.process_payment = MagicMock()
-    incomplete_repo.refund_payment = MagicMock()
     incomplete_repo.get_payment = "not_a_function"  # Not callable
+    incomplete_repo.refund_payment = MagicMock()  # Add missing method
 
     # @runtime_checkable doesn't detect non-callable attributes
     # This is expected behaviour - isinstance() only checks attribute
@@ -241,12 +228,8 @@ def test_validate_pydantic_response_invalid_state() -> None:
 
 def test_create_validated_repository_factory_success() -> None:
     """Test creating a validated repository factory"""
-    mock_minio_payment_repo = MagicMock(spec=MinioPaymentRepository)
-
     # Test the factory with a concrete implementation
-    repo = TemporalMinioPaymentRepository(
-        mock_minio_payment_repo
-    )  # Fixed: only pass payment repo
+    repo = TemporalMinioPaymentRepository("test-endpoint")
 
     # Validate that the created repository satisfies the protocol
     assert isinstance(repo, PaymentRepository)
@@ -273,10 +256,7 @@ def test_create_validated_repository_factory_invalid_implementation() -> None:
 
 def test_ensure_payment_repository_success() -> None:
     """Test convenience function for payment repository validation"""
-    mock_minio_payment_repo = MagicMock(spec=MinioPaymentRepository)
-    repo = TemporalMinioPaymentRepository(
-        mock_minio_payment_repo
-    )  # Fixed: only pass payment repo
+    repo = TemporalMinioPaymentRepository("test-endpoint")
 
     # Should not raise any exception
     ensure_payment_repository(repo)
@@ -307,7 +287,8 @@ def test_inventory_repository_validation() -> None:
 def test_factory_function_metadata() -> None:
     """Test that factory function has proper metadata"""
     factory = create_validated_repository_factory(
-        PaymentRepository, TemporalMinioPaymentRepository  # type: ignore[type-abstract]
+        PaymentRepository,
+        TemporalMinioPaymentRepository,  # type: ignore[type-abstract]
     )
 
     assert (
@@ -363,10 +344,7 @@ def test_validation_preserves_pydantic_validation_errors() -> None:
 
 def test_temporal_activity_method_validation() -> None:
     """Test that Temporal activity-decorated methods are handled properly"""
-    mock_minio_payment_repo = MagicMock(spec=MinioPaymentRepository)
-    repo = TemporalMinioPaymentRepository(
-        mock_minio_payment_repo
-    )  # Fixed: only pass payment repo
+    repo = TemporalMinioPaymentRepository("test-endpoint")
 
     # This should pass even though the methods are decorated with
     # @activity.defn
@@ -383,10 +361,7 @@ def test_temporal_activity_method_validation() -> None:
 def test_isinstance_works_with_runtime_checkable() -> None:
     """Test that isinstance() works directly with @runtime_checkable
     protocols"""
-    mock_minio_payment_repo = MagicMock(spec=MinioPaymentRepository)
-    repo = TemporalMinioPaymentRepository(
-        mock_minio_payment_repo
-    )  # Fixed: only pass payment repo
+    repo = TemporalMinioPaymentRepository("test-endpoint")
 
     # Direct isinstance check should work
     assert isinstance(repo, PaymentRepository)

--- a/sample/tests/test_validation.py
+++ b/sample/tests/test_validation.py
@@ -4,7 +4,7 @@ Tests for runtime validation utilities.
 
 import pytest
 import warnings
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from decimal import Decimal
 
 from sample.validation import (
@@ -29,13 +29,18 @@ from sample.domain import Order, Payment, OrderItem
 def test_runtime_checkable_validation_success() -> None:
     """Test that @runtime_checkable validation works correctly"""
     # Test with the Temporal Activity implementation
-    repo = TemporalMinioPaymentRepository("test-endpoint")
+    with patch("sample.repos.minio.payment.Minio") as mock_minio:
+        mock_client = MagicMock()
+        mock_minio.return_value = mock_client
+        mock_client.bucket_exists.return_value = True
 
-    # Should not raise
-    assert isinstance(repo, PaymentRepository)
+        repo = TemporalMinioPaymentRepository("test-endpoint")
 
-    # isinstance should work directly
-    assert isinstance(repo, PaymentRepository)
+        # Should not raise
+        assert isinstance(repo, PaymentRepository)
+
+        # isinstance should work directly
+        assert isinstance(repo, PaymentRepository)
 
 
 def test_runtime_checkable_validation_failure() -> None:
@@ -60,39 +65,55 @@ def test_runtime_checkable_validation_failure() -> None:
 
 def test_ensure_repository_provides_type_safety() -> None:
     """Test that ensure_* functions provide proper typing"""
-    repo = TemporalMinioPaymentRepository("test-endpoint")
+    with patch("sample.repos.minio.payment.Minio") as mock_minio:
+        mock_client = MagicMock()
+        mock_minio.return_value = mock_client
+        mock_client.bucket_exists.return_value = True
 
-    # This should pass both runtime and static type checking
-    validated_repo = ensure_payment_repository(repo)
+        repo = TemporalMinioPaymentRepository("test-endpoint")
 
-    # Type checker knows this is a PaymentRepository
-    assert hasattr(validated_repo, "process_payment")
-    assert hasattr(validated_repo, "get_payment")
+        # This should pass both runtime and static type checking
+        validated_repo = ensure_payment_repository(repo)
+
+        # Type checker knows this is a PaymentRepository
+        assert hasattr(validated_repo, "process_payment")
+        assert hasattr(validated_repo, "get_payment")
 
 
 def test_isinstance_works_with_all_protocols() -> None:
     """Test isinstance works with all repository protocols"""
-    payment_repo = TemporalMinioPaymentRepository("test-endpoint")
+    with patch("sample.repos.minio.payment.Minio") as mock_minio:
+        mock_client = MagicMock()
+        mock_minio.return_value = mock_client
+        mock_client.bucket_exists.return_value = True
 
-    mock_minio_inventory_repo = MagicMock(spec=MinioInventoryRepository)
-    inventory_repo = TemporalMinioInventoryRepository(
-        mock_minio_inventory_repo
-    )
+        payment_repo = TemporalMinioPaymentRepository("test-endpoint")
 
-    assert isinstance(payment_repo, PaymentRepository)
-    assert isinstance(inventory_repo, InventoryRepository)
+        mock_minio_inventory_repo = MagicMock(spec=MinioInventoryRepository)
+        inventory_repo = TemporalMinioInventoryRepository(
+            mock_minio_inventory_repo
+        )
 
-    # Cross-protocol checks should fail
-    assert not isinstance(payment_repo, InventoryRepository)
-    assert not isinstance(inventory_repo, PaymentRepository)
+        assert isinstance(payment_repo, PaymentRepository)
+        assert isinstance(inventory_repo, InventoryRepository)
+
+        # Cross-protocol checks should fail
+        assert not isinstance(payment_repo, InventoryRepository)
+        assert not isinstance(inventory_repo, PaymentRepository)
 
 
 def test_validate_repository_protocol_success() -> None:
     """Test successful repository protocol validation"""
-    repo = TemporalMinioPaymentRepository("test-endpoint")
+    with patch("sample.repos.minio.payment.Minio") as mock_minio:
+        mock_client = MagicMock()
+        mock_minio.return_value = mock_client
+        mock_client.bucket_exists.return_value = True
 
-    # Should not raise any exception - just verify it's a PaymentRepository
-    assert isinstance(repo, PaymentRepository)
+        repo = TemporalMinioPaymentRepository("test-endpoint")
+
+        # Should not raise any exception - just verify it's a
+        # PaymentRepository
+        assert isinstance(repo, PaymentRepository)
 
 
 def test_validate_repository_protocol_missing_method() -> None:
@@ -229,11 +250,16 @@ def test_validate_pydantic_response_invalid_state() -> None:
 def test_create_validated_repository_factory_success() -> None:
     """Test creating a validated repository factory"""
     # Test the factory with a concrete implementation
-    repo = TemporalMinioPaymentRepository("test-endpoint")
+    with patch("sample.repos.minio.payment.Minio") as mock_minio:
+        mock_client = MagicMock()
+        mock_minio.return_value = mock_client
+        mock_client.bucket_exists.return_value = True
 
-    # Validate that the created repository satisfies the protocol
-    assert isinstance(repo, PaymentRepository)
-    assert isinstance(repo, TemporalMinioPaymentRepository)
+        repo = TemporalMinioPaymentRepository("test-endpoint")
+
+        # Validate that the created repository satisfies the protocol
+        assert isinstance(repo, PaymentRepository)
+        assert isinstance(repo, TemporalMinioPaymentRepository)
 
 
 def test_create_validated_repository_factory_invalid_implementation() -> None:
@@ -256,10 +282,15 @@ def test_create_validated_repository_factory_invalid_implementation() -> None:
 
 def test_ensure_payment_repository_success() -> None:
     """Test convenience function for payment repository validation"""
-    repo = TemporalMinioPaymentRepository("test-endpoint")
+    with patch("sample.repos.minio.payment.Minio") as mock_minio:
+        mock_client = MagicMock()
+        mock_minio.return_value = mock_client
+        mock_client.bucket_exists.return_value = True
 
-    # Should not raise any exception
-    ensure_payment_repository(repo)
+        repo = TemporalMinioPaymentRepository("test-endpoint")
+
+        # Should not raise any exception
+        ensure_payment_repository(repo)
 
 
 def test_ensure_payment_repository_failure() -> None:
@@ -344,30 +375,40 @@ def test_validation_preserves_pydantic_validation_errors() -> None:
 
 def test_temporal_activity_method_validation() -> None:
     """Test that Temporal activity-decorated methods are handled properly"""
-    repo = TemporalMinioPaymentRepository("test-endpoint")
+    with patch("sample.repos.minio.payment.Minio") as mock_minio:
+        mock_client = MagicMock()
+        mock_minio.return_value = mock_client
+        mock_client.bucket_exists.return_value = True
 
-    # This should pass even though the methods are decorated with
-    # @activity.defn
-    # The validation system should handle Temporal activities gracefully
-    assert isinstance(repo, PaymentRepository)
+        repo = TemporalMinioPaymentRepository("test-endpoint")
 
-    # Verify the methods exist and are callable
-    assert hasattr(repo, "process_payment")
-    assert hasattr(repo, "get_payment")
-    assert callable(repo.process_payment)
-    assert callable(repo.get_payment)
+        # This should pass even though the methods are decorated with
+        # @activity.defn
+        # The validation system should handle Temporal activities gracefully
+        assert isinstance(repo, PaymentRepository)
+
+        # Verify the methods exist and are callable
+        assert hasattr(repo, "process_payment")
+        assert hasattr(repo, "get_payment")
+        assert callable(repo.process_payment)
+        assert callable(repo.get_payment)
 
 
 def test_isinstance_works_with_runtime_checkable() -> None:
     """Test that isinstance() works directly with @runtime_checkable
     protocols"""
-    repo = TemporalMinioPaymentRepository("test-endpoint")
+    with patch("sample.repos.minio.payment.Minio") as mock_minio:
+        mock_client = MagicMock()
+        mock_minio.return_value = mock_client
+        mock_client.bucket_exists.return_value = True
 
-    # Direct isinstance check should work
-    assert isinstance(repo, PaymentRepository)
+        repo = TemporalMinioPaymentRepository("test-endpoint")
 
-    # Cross-protocol checks should fail
-    assert not isinstance(repo, InventoryRepository)
+        # Direct isinstance check should work
+        assert isinstance(repo, PaymentRepository)
+
+        # Cross-protocol checks should fail
+        assert not isinstance(repo, InventoryRepository)
 
 
 def test_runtime_checkable_limitation_with_non_callable() -> None:

--- a/sample/tests/test_workflow.py
+++ b/sample/tests/test_workflow.py
@@ -48,16 +48,20 @@ class TestOrderFulfillmentWorkflow:
 
                 # Mock the specific Temporal proxy classes expected by the
                 # workflow
-                with patch(
-                    "sample.repos.temporal.proxies.order.WorkflowOrderRepositoryProxy"
-                ), patch(
-                    "sample.repos.temporal.proxies.payment.WorkflowPaymentRepositoryProxy"
-                ), patch(
-                    "sample.repos.temporal.proxies.inventory.WorkflowInventoryRepositoryProxy"
-                ), patch(
-                    "sample.repos.temporal.proxies.order_request.WorkflowOrderRequestRepositoryProxy"
+                with (
+                    patch(
+                        "sample.repos.temporal.proxies.order.WorkflowOrderRepositoryProxy"
+                    ),
+                    patch(
+                        "sample.repos.temporal.proxies.payment.WorkflowPaymentRepositoryProxy"
+                    ),
+                    patch(
+                        "sample.repos.temporal.proxies.inventory.WorkflowInventoryRepositoryProxy"
+                    ),
+                    patch(
+                        "sample.repos.temporal.proxies.order_request.WorkflowOrderRequestRepositoryProxy"
+                    ),
                 ):
-
                     # Import and test the workflow logic without executing it
                     from sample.workflow import OrderFulfillmentWorkflow
 
@@ -114,16 +118,18 @@ class TestCancelOrderWorkflow:
 
                 # Mock the specific Temporal proxy classes expected by the
                 # workflow
-                with patch(
-                    "sample.repos.temporal.proxies.order.WorkflowOrderRepositoryProxy"
-                ), patch(
-                    "sample.repos.temporal.proxies.payment.WorkflowPaymentRepositoryProxy"
-                ), patch(
-                    "sample.repos.temporal.proxies.inventory.WorkflowInventoryRepositoryProxy"
-                ), patch(
-                    "temporalio.workflow.info"
-                ) as mock_workflow_info:
-
+                with (
+                    patch(
+                        "sample.repos.temporal.proxies.order.WorkflowOrderRepositoryProxy"
+                    ),
+                    patch(
+                        "sample.repos.temporal.proxies.payment.WorkflowPaymentRepositoryProxy"
+                    ),
+                    patch(
+                        "sample.repos.temporal.proxies.inventory.WorkflowInventoryRepositoryProxy"
+                    ),
+                    patch("temporalio.workflow.info") as mock_workflow_info,
+                ):
                     mock_workflow_info.return_value.run_id = "test-run-id"
 
                     # Import and test the workflow logic without executing it

--- a/sample/usecase.py
+++ b/sample/usecase.py
@@ -465,8 +465,7 @@ class OrderFulfillmentUseCase:
                     order_id=order.order_id,
                     status="PAYMENT_FAILED",
                     reason=(
-                        "Payment processing failed: "
-                        f"{payment_outcome.reason}"
+                        f"Payment processing failed: {payment_outcome.reason}"
                     ),
                 )
 
@@ -1037,8 +1036,7 @@ class CancelOrderUseCase:
                 order_id=order_id,
                 status="FAILED",  # Or "FAILED_CANCELLATION" if we add it
                 reason=(
-                    "Cancellation failed due to unexpected error: "
-                    f"{str(e)}"
+                    f"Cancellation failed due to unexpected error: {str(e)}"
                 ),
                 refund_id=order.refund_id,  # Use new field
                 refund_status=order.refund_status,  # Use new field


### PR DESCRIPTION
This is just an example showing how a class decorator can be used to avoid the current "Three-layer repository pattern".

I've left the definition of the `TemporalMinioPaymentRepository` in the `sample/repos/minio_payments.py` module, but that isn't necessary - if we tested the decorator separately, it can just be part of the workflow repository instantiation, such as:

```python
TemporalMinioPaymentRepository: type[MinioPaymentRepository] = temporal_repository("sample.payment_repo")(MinioPaymentRepository)
```
in the `proxies/payment.py` module.

I'm not suggesting this change for merging as it's not complete at the moment: I've ignored the required naming conventions - we'd need to do something so we can get the use-case in the name correctly (as in the existing code on master they differ for the same class depending on the function - with the `process_payment` being for `order_fulfillment` use-case while the `refund_payment` method is for the `cancel_order` use-case).

I did originally think a drawback here was that we lose the neat dependency injection for the `TemporalMinioPaymentRepository`, but realised we don't - in that we still have `MinioPaymentRepository` and the `WorkflowPaymentRepositoryProxy` implementing the protocol only... the difference is just that the middle layer disappears (ie. we don't need dependency injection there, we just need to test the decorator separately).

This same decorator could be used for the other repositories too without any changes, removing more code (Orders, OrderRequests, Inventory).

Let me know if you think it's worthwhile and I'll spend a bit more time to ensure we can have the names we want and remove the other code.

(Aside: is it actually correct in master that we're hard-coding the business use-cases to the method names? I think you mentioned that a method might be used in different use-cases... one example would be get_payment which is currently hard-coded to `order_fulfillment` - maybe the workflow should have the use-case, but not the activity? Not sure).