### PR TITLE
adopt docker compose syntax (no hyphen)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,19 +48,19 @@ e2e-test-run: reports
 	@echo "Running E2E tests..."
 	@pytest -m e2e --junitxml=reports/e2e-results.xml
 	@echo "Capturing infrastructure logs for debugging..."
-	@docker-compose -f docker-compose.test.yml logs > reports/e2e-infrastructure.log 2>&1
+	@docker compose -f docker-compose.test.yml logs > reports/e2e-infrastructure.log 2>&1
 
 # like e2e-test-run but stop on first failure
 e2e-test-run-x: reports
 	@echo "Running E2E tests..."
 	@pytest -m e2e --junitxml=reports/e2e-results.xml -x
 	@echo "Capturing infrastructure logs for debugging..."
-	@docker-compose -f docker-compose.test.yml logs > reports/e2e-infrastructure.log 2>&1
+	@docker compose -f docker-compose.test.yml logs > reports/e2e-infrastructure.log 2>&1
 
 # E2E test teardown (stops and removes ephemeral infrastructure)
 e2e-test-teardown:
 	@echo "Cleaning up ephemeral test infrastructure..."
-	@docker-compose -f docker-compose.test.yml down -v
+	@docker compose -f docker-compose.test.yml down -v
 	@echo "Ephemeral test infrastructure cleaned up."
 
 # Full E2E tests (orchestrates setup, run, teardown)

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ test-unit: reports
 # E2E test setup (starts ephemeral infrastructure)
 e2e-test-setup: reports
 	@echo "Starting ephemeral test infrastructure..."
-	docker-compose -f docker-compose.test.yml build
-	docker-compose -f docker-compose.test.yml up -d --force-recreate
+	docker compose -f docker-compose.test.yml build
+	docker compose -f docker-compose.test.yml up -d --force-recreate
 	@echo "Waiting for services to be healthy..."
-	@timeout 120 bash -c 'until docker-compose -f docker-compose.test.yml ps | grep -q "healthy"; do echo "Waiting for health checks..."; docker-compose -f docker-compose.test.yml ps; sleep 5; done' || (echo "Services failed to start, capturing logs..." && docker-compose -f docker-compose.test.yml logs > reports/e2e-infrastructure.log 2>&1 && docker-compose -f docker-compose.test.yml down -v && exit 1)
+	@timeout 120 bash -c 'until docker compose -f docker-compose.test.yml ps | grep -q "healthy"; do echo "Waiting for health checks..."; docker compose -f docker-compose.test.yml ps; sleep 5; done' || (echo "Services failed to start, capturing logs..." && docker compose -f docker-compose.test.yml logs > reports/e2e-infrastructure.log 2>&1 && docker compose -f docker-compose.test.yml down -v && exit 1)
 	@echo "Ephemeral test infrastructure is healthy."
 
 # E2E test run (runs pytest against running infrastructure)


### PR DESCRIPTION
my bad, was stuck in the dark ages wearing out my hyphen key by typing `docker-compose` (chump), when all the cool kids type `docker compose` these days...