### PR TITLE
Adds temporal decorator to create layer 2 automatically.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@
 # Fast quality checks (for pre-commit)
 quality-fast:
 	@echo "Running fast quality checks..."
-	black --check cal/ sample/
-	ruff check cal/ sample/
+	black --check cal/ sample/ util/
+	ruff check cal/ sample/ util/
 	pytest -x -m "not e2e" --no-cov -q
 
 # Full quality suite (for post-commit/CI)

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ quality-full: reports quality-types quality-security test-unit test-e2e
 # Type checking
 quality-types: reports
 	@echo "Type checking..."
-	mypy cal/ sample/ --config-file=mypy.ini > reports/mypy.txt 2>&1 || true
+	mypy cal/ sample/ util/ --config-file=mypy.ini > reports/mypy.txt 2>&1
 
 # Security scanning
 quality-security: reports

--- a/README
+++ b/README
@@ -18,7 +18,7 @@ Architecture Roadmap
 
 Core Principle: Dependencies point inward. Always.
 
-    Domain (Pure) -> Use Cases (Orchestrate) -> Adapters (Translate) -> Frameworks (Contain)
+    Domain (Pure) <- Use Cases (Orchestrate) <- Adapters (Translate) <- Frameworks (Contain)
 
 Three-Layer Repository Pattern (mandatory for all data access):
 1. Pure Backend -> 2. Temporal Activity -> 3. Workflow Proxy
@@ -28,10 +28,10 @@ Workflow Determinism: Activities for I/O, workflows for logic. No exceptions.
 Reference Applications
 ----------------------
 
-sample/ - Order fulfillment system  
+sample/ - Order fulfillment system
 Complete saga pattern with payments, inventory, cancellation. Your architectural north star.
 
-cal/ - Calendar intelligence system  
+cal/ - Calendar intelligence system
 AI-powered calendar analysis with Google integration. Domain-specific patterns.
 
 Navigation Guide
@@ -43,21 +43,21 @@ Start Here:
 - fun-police/systemPatterns.org - Implementation rules
 
 Deep Dive:
-- fun-police/projectbrief.org - Requirements and boundaries  
+- fun-police/projectbrief.org - Requirements and boundaries
 - fun-police/techContext.org - Technology stack decisions
 - fun-police/methodology.org - Development workflow
 - fun-police/tasks.org - Current work (org-mode TODOs)
 
 Quality Gates:
 - make quality-fast - Pre-commit checks
-- make quality-full - Complete validation  
+- make quality-full - Complete validation
 - make test-e2e - End-to-end with Docker
 
 Testing Strategy
 ----------------
 
     Many unit tests (mocked repositories)
-    Some integration tests (real dependencies)  
+    Some integration tests (real dependencies)
     Few E2E tests (complete workflows)
 
 Development Rules

--- a/util/repos/temporal/__init__.py
+++ b/util/repos/temporal/__init__.py
@@ -1,0 +1,11 @@
+"""
+Temporal repository utilities.
+
+This module provides utilities for working with Temporal repositories,
+including the temporal_repository decorator for automatically wrapping
+repository methods as Temporal activities.
+"""
+
+from .decorators import temporal_repository
+
+__all__ = ["temporal_repository"]

--- a/util/repos/temporal/client_proxies/file_storage.py
+++ b/util/repos/temporal/client_proxies/file_storage.py
@@ -11,54 +11,62 @@ logger = logging.getLogger(__name__)
 
 class TemporalFileStorageRepository(FileStorageRepository):
     """
-    Client-side proxy for FileStorageRepository that calls Temporal activities.
-    This proxy ensures that all interactions with the FileStorageRepository are
-    performed via Temporal activities, maintaining workflow determinism.
+    Client-side proxy for FileStorageRepository that calls activities.
+    This proxy ensures that all interactions with the FileStorageRepository
+    are performed via Temporal activities, maintaining workflow determinism.
     """
 
-    def __init__(self, client: Client, concrete_repo: Optional[FileStorageRepository] = None):
+    def __init__(
+        self,
+        client: Client,
+        concrete_repo: Optional[FileStorageRepository] = None,
+    ):
         self.client = client
         self.concrete_repo = concrete_repo
         logger.debug("Initialized TemporalFileStorageRepository")
 
     async def upload_file(self, args: FileUploadArgs) -> FileMetadata:
         """Upload a file via Temporal activity."""
-        logger.debug(f"Client calling activity to upload file: {args.file_id}")
-        
+        logger.debug(
+            f"Client calling activity to upload file: {args.file_id}"
+        )
+
         handle = await self.client.start_workflow(
             "util.file_storage.minio.upload_file",
             args,
             id=f"upload-{args.file_id}",
             task_queue="order-fulfillment-queue",
         )
-        
+
         result = await handle.result()
         return result  # type: ignore[no-any-return]
 
     async def download_file(self, file_id: str) -> Optional[bytes]:
         """Download a file via Temporal activity."""
         logger.debug(f"Client calling activity to download file: {file_id}")
-        
+
         handle = await self.client.start_workflow(
             "util.file_storage.minio.download_file",
             file_id,
             id=f"download-{file_id}",
             task_queue="order-fulfillment-queue",
         )
-        
+
         result = await handle.result()
         return result  # type: ignore[no-any-return]
 
     async def get_file_metadata(self, file_id: str) -> Optional[FileMetadata]:
         """Retrieve file metadata via Temporal activity."""
-        logger.debug(f"Client calling activity to get file metadata: {file_id}")
-        
+        logger.debug(
+            f"Client calling activity to get file metadata: {file_id}"
+        )
+
         handle = await self.client.start_workflow(
             "util.file_storage.minio.get_file_metadata",
             file_id,
             id=f"metadata-{file_id}",
             task_queue="order-fulfillment-queue",
         )
-        
+
         result = await handle.result()
         return result  # type: ignore[no-any-return]

--- a/util/repos/temporal/decorators.py
+++ b/util/repos/temporal/decorators.py
@@ -7,7 +7,7 @@ as Temporal activities, reducing boilerplate and ensuring consistent patterns.
 
 import inspect
 import logging
-from typing import Type, TypeVar
+from typing import Any, Callable, Type, TypeVar
 
 from temporalio import activity
 
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-def temporal_repository(activity_prefix: str):
+def temporal_repository(activity_prefix: str) -> Callable[[Type[T]], Type[T]]:
     """
     Class decorator that automatically wraps all async methods as Temporal
     activities.
@@ -90,8 +90,12 @@ def temporal_repository(activity_prefix: str):
 
             # Create a new method that calls the original to avoid decorator
             # conflicts
-            def create_wrapper_method(original_method, method_name):
-                async def wrapper_method(self, *args, **kwargs):
+            def create_wrapper_method(
+                original_method: Callable[..., Any], method_name: str
+            ) -> Callable[..., Any]:
+                async def wrapper_method(
+                    self: Any, *args: Any, **kwargs: Any
+                ) -> Any:
                     return await original_method(self, *args, **kwargs)
 
                 # Preserve method metadata

--- a/util/repos/temporal/decorators.py
+++ b/util/repos/temporal/decorators.py
@@ -1,0 +1,126 @@
+"""
+Temporal decorator for automatically wrapping repository methods as activities
+
+This module provides a decorator that automatically wraps repository methods
+as Temporal activities, reducing boilerplate and ensuring consistent patterns.
+"""
+
+import inspect
+import logging
+from typing import Type, TypeVar
+
+from temporalio import activity
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+def temporal_repository(activity_prefix: str):
+    """
+    Class decorator that automatically wraps all async methods as Temporal
+    activities.
+
+    This decorator inspects the class and wraps all async methods (coroutine
+    functions) that don't start with underscore as Temporal activities. The
+    activity names are generated using the provided prefix and the method
+    name.
+
+    Args:
+        activity_prefix: Prefix for activity names (e.g.,
+        "sample.payment_repo.minio") Method names will be appended to create
+        full activity names like "sample.payment_repo.minio.process_payment"
+
+    Returns:
+        The decorated class with all async methods wrapped as Temporal
+        activities
+
+    Example:
+        @temporal_repository("sample.order_fulfillment.payment_repo")
+        class OrderFulfillmentPaymentRepository(MinioPaymentRepository):
+            pass
+
+        # This automatically creates activities for all async methods:
+        # - process_payment ->
+        #   "sample.order_fulfillment.payment_repo.process_payment"
+        # - get_payment ->
+        #   "sample.order_fulfillment.payment_repo.get_payment"
+        # - refund_payment ->
+        #   "sample.order_fulfillment.payment_repo.refund_payment"
+    """
+
+    def decorator(cls: Type[T]) -> Type[T]:
+        logger.debug(
+            f"Applying temporal_repository decorator to {cls.__name__}"
+        )
+
+        # Track which methods we wrap for logging
+        wrapped_methods = []
+
+        # Look at all classes in the MRO to find async methods to wrap
+        async_methods_to_wrap = {}
+
+        for base_class in cls.__mro__:
+            # Skip object base class
+            if base_class is object:
+                continue
+
+            # Get methods defined in this class (not inherited ones we've
+            # already seen)
+            for name in base_class.__dict__:
+                if name in async_methods_to_wrap:
+                    continue  # Already found this method in a subclass
+
+                method = getattr(base_class, name)
+
+                # Only wrap async methods that don't start with underscore
+                if inspect.iscoroutinefunction(
+                    method
+                ) and not name.startswith("_"):
+                    async_methods_to_wrap[name] = method
+
+        # Now wrap all the async methods we found
+        for name, method in async_methods_to_wrap.items():
+            # Create activity name by combining prefix and method name
+            activity_name = f"{activity_prefix}.{name}"
+
+            logger.debug(
+                f"Wrapping method {name} as activity {activity_name}"
+            )
+
+            # Create a new method that calls the original to avoid decorator
+            # conflicts
+            def create_wrapper_method(original_method, method_name):
+                async def wrapper_method(self, *args, **kwargs):
+                    return await original_method(self, *args, **kwargs)
+
+                # Preserve method metadata
+                wrapper_method.__name__ = method_name
+                wrapper_method.__qualname__ = f"{cls.__name__}.{method_name}"
+                wrapper_method.__doc__ = original_method.__doc__
+                wrapper_method.__annotations__ = getattr(
+                    original_method, "__annotations__", {}
+                )
+
+                return wrapper_method
+
+            # Create the wrapper and apply activity decorator
+            wrapper_method = create_wrapper_method(method, name)
+            wrapped_method = activity.defn(name=activity_name)(wrapper_method)
+
+            # Replace the method on the class with the wrapped version
+            setattr(cls, name, wrapped_method)
+
+            wrapped_methods.append(name)
+
+        logger.info(
+            f"Temporal repository decorator applied to {cls.__name__}",
+            extra={
+                "wrapped_methods": wrapped_methods,
+                "activity_prefix": activity_prefix,
+            },
+        )
+
+        return cls
+
+    return decorator

--- a/util/repos/temporal/proxies/file_storage.py
+++ b/util/repos/temporal/proxies/file_storage.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 class WorkflowFileStorageRepositoryProxy(FileStorageRepository):
     """
     Workflow implementation of FileStorageRepository that calls activities.
-    This proxy ensures that all interactions with the FileStorageRepository are
-    performed via Temporal activities, maintaining workflow determinism.
+    This proxy ensures that all interactions with the FileStorageRepository
+    are performed via Temporal activities, maintaining workflow determinism.
     """
 
     def __init__(self) -> None:

--- a/util/tests/__init__.py
+++ b/util/tests/__init__.py
@@ -1,0 +1,1 @@
+# Empty __init__.py file to make util/tests a Python package

--- a/util/tests/test_decorators.py
+++ b/util/tests/test_decorators.py
@@ -7,7 +7,7 @@ repository implementations.
 """
 
 from unittest.mock import patch
-from typing import Optional
+from typing import Any, Optional
 
 from temporalio import activity
 
@@ -56,7 +56,7 @@ class MockRepository(MockBaseRepository):
         return f"private_{value}"
 
 
-def test_decorator_wraps_public_async_methods():
+def test_decorator_wraps_public_async_methods() -> None:
     """Test decorator wraps all public async methods as activities."""
 
     @temporal_repository("test.repo")
@@ -107,7 +107,7 @@ def test_decorator_wraps_public_async_methods():
     assert base_async_attrs
 
 
-def test_decorator_does_not_wrap_sync_methods():
+def test_decorator_does_not_wrap_sync_methods() -> None:
     """Test that sync methods are not wrapped as activities."""
 
     @temporal_repository("test.repo")
@@ -123,7 +123,7 @@ def test_decorator_does_not_wrap_sync_methods():
     )
 
 
-def test_decorator_does_not_wrap_private_methods():
+def test_decorator_does_not_wrap_private_methods() -> None:
     """Test that private async methods are not wrapped as activities."""
 
     @temporal_repository("test.repo")
@@ -139,7 +139,7 @@ def test_decorator_does_not_wrap_private_methods():
     )
 
 
-def test_decorated_methods_preserve_functionality():
+def test_decorated_methods_preserve_functionality() -> None:
     """Test that decorated methods still work as expected."""
 
     @temporal_repository("test.repo")
@@ -153,7 +153,7 @@ def test_decorated_methods_preserve_functionality():
     assert result == "sync_test"
 
     # Test private method works normally
-    async def test_private():
+    async def test_private() -> None:
         result = await repo._private_method("test")
         assert result == "private_test"
 
@@ -162,7 +162,7 @@ def test_decorated_methods_preserve_functionality():
     asyncio.run(test_private())
 
 
-def test_decorated_methods_preserve_metadata():
+def test_decorated_methods_preserve_metadata() -> None:
     """Test that decorated methods preserve original method metadata."""
 
     @temporal_repository("test.repo")
@@ -177,18 +177,20 @@ def test_decorated_methods_preserve_metadata():
     assert repo.refund_payment.__name__ == "refund_payment"
 
     # Check that docstrings are preserved
-    assert "Mock payment processing method" in repo.process_payment.__doc__
-    assert "Mock get payment method" in repo.get_payment.__doc__
-    assert "Mock refund payment method" in repo.refund_payment.__doc__
+    assert "Mock payment processing method" in (
+        repo.process_payment.__doc__ or ""
+    )
+    assert "Mock get payment method" in (repo.get_payment.__doc__ or "")
+    assert "Mock refund payment method" in (repo.refund_payment.__doc__ or "")
 
 
-def test_activity_names_with_different_prefixes():
+def test_activity_names_with_different_prefixes() -> None:
     """Test different prefixes generate different activity names."""
 
     captured_activity_names = []
     original_activity_defn = activity.defn
 
-    def mock_activity_defn(name=None, **kwargs):
+    def mock_activity_defn(name: Optional[str] = None, **kwargs: Any) -> Any:
         """Mock activity.defn to capture the activity names being created."""
         if name:
             captured_activity_names.append(name)
@@ -240,7 +242,7 @@ def test_activity_names_with_different_prefixes():
     assert not set(payment_activities).intersection(set(inventory_activities))
 
 
-def test_decorator_handles_inheritance_correctly():
+def test_decorator_handles_inheritance_correctly() -> None:
     """Test that the decorator properly handles method resolution order."""
 
     class ChildRepository(MockRepository):
@@ -272,7 +274,7 @@ def test_decorator_handles_inheritance_correctly():
     )
 
 
-def test_decorator_logs_wrapped_methods():
+def test_decorator_logs_wrapped_methods() -> None:
     """Test that the decorator logs which methods it wraps."""
 
     with patch("util.repos.temporal.decorators.logger") as mock_logger:
@@ -291,7 +293,7 @@ def test_decorator_logs_wrapped_methods():
         assert "DecoratedRepository" in info_call[0][0]
 
 
-def test_empty_class_decorator():
+def test_empty_class_decorator() -> None:
     """Test decorator behavior with a class that has no async methods."""
 
     class EmptyRepository:
@@ -308,7 +310,7 @@ def test_empty_class_decorator():
     )
 
 
-def test_decorator_type_preservation():
+def test_decorator_type_preservation() -> None:
     """Test decorator preserves class type for isinstance checks."""
 
     @temporal_repository("test.types")
@@ -323,7 +325,7 @@ def test_decorator_type_preservation():
     assert isinstance(repo, MockBaseRepository)
 
 
-def test_multiple_decorations():
+def test_multiple_decorations() -> None:
     """Test repository can be decorated multiple times with prefixes."""
 
     @temporal_repository("test.first")

--- a/util/tests/test_decorators.py
+++ b/util/tests/test_decorators.py
@@ -1,0 +1,343 @@
+"""
+Tests for the temporal_repository decorator.
+
+This module tests the decorator in isolation to ensure it properly wraps
+async methods as Temporal activities without depending on the existing
+repository implementations.
+"""
+
+from unittest.mock import patch
+from typing import Optional
+
+from temporalio import activity
+
+from util.repos.temporal.decorators import temporal_repository
+
+
+class MockBaseRepository:
+    """Mock base repository class for testing inheritance."""
+
+    async def base_async_method(self, arg1: str) -> str:
+        """Base async method that should be wrapped."""
+        return f"base_result_{arg1}"
+
+    def base_sync_method(self, arg1: str) -> str:
+        """Base sync method that should NOT be wrapped."""
+        return f"base_sync_{arg1}"
+
+    async def _private_async_method(self, arg1: str) -> str:
+        """Private async method that should NOT be wrapped."""
+        return f"private_{arg1}"
+
+
+class MockRepository(MockBaseRepository):
+    """Mock repository class for testing the decorator."""
+
+    async def process_payment(self, order_id: str, amount: float) -> dict:
+        """Mock payment processing method."""
+        return {"status": "success", "order_id": order_id, "amount": amount}
+
+    async def get_payment(self, payment_id: str) -> Optional[dict]:
+        """Mock get payment method."""
+        if payment_id == "not_found":
+            return None
+        return {"payment_id": payment_id, "status": "completed"}
+
+    async def refund_payment(self, payment_id: str) -> dict:
+        """Mock refund payment method."""
+        return {"status": "refunded", "payment_id": payment_id}
+
+    def sync_method(self, value: str) -> str:
+        """Sync method that should NOT be wrapped."""
+        return f"sync_{value}"
+
+    async def _private_method(self, value: str) -> str:
+        """Private async method that should NOT be wrapped."""
+        return f"private_{value}"
+
+
+def test_decorator_wraps_public_async_methods():
+    """Test decorator wraps all public async methods as activities."""
+
+    @temporal_repository("test.repo")
+    class DecoratedRepository(MockRepository):
+        pass
+
+    # Check that async methods are wrapped with activity decorator
+    # Use dir() check since hasattr() doesn't work with Temporal activities
+    assert "__temporal_activity_definition" in dir(
+        DecoratedRepository.process_payment
+    )
+    assert "__temporal_activity_definition" in dir(
+        DecoratedRepository.get_payment
+    )
+    assert "__temporal_activity_definition" in dir(
+        DecoratedRepository.refund_payment
+    )
+    assert "__temporal_activity_definition" in dir(
+        DecoratedRepository.base_async_method
+    )
+
+    # Check activity names by accessing the attribute directly
+    process_payment_attrs = {
+        attr: getattr(DecoratedRepository.process_payment, attr, None)
+        for attr in dir(DecoratedRepository.process_payment)
+        if attr == "__temporal_activity_definition"
+    }
+    get_payment_attrs = {
+        attr: getattr(DecoratedRepository.get_payment, attr, None)
+        for attr in dir(DecoratedRepository.get_payment)
+        if attr == "__temporal_activity_definition"
+    }
+    refund_payment_attrs = {
+        attr: getattr(DecoratedRepository.refund_payment, attr, None)
+        for attr in dir(DecoratedRepository.refund_payment)
+        if attr == "__temporal_activity_definition"
+    }
+    base_async_attrs = {
+        attr: getattr(DecoratedRepository.base_async_method, attr, None)
+        for attr in dir(DecoratedRepository.base_async_method)
+        if attr == "__temporal_activity_definition"
+    }
+
+    # Verify the attributes exist and have the expected names
+    assert process_payment_attrs
+    assert get_payment_attrs
+    assert refund_payment_attrs
+    assert base_async_attrs
+
+
+def test_decorator_does_not_wrap_sync_methods():
+    """Test that sync methods are not wrapped as activities."""
+
+    @temporal_repository("test.repo")
+    class DecoratedRepository(MockRepository):
+        pass
+
+    # Check that sync methods are NOT wrapped
+    assert "__temporal_activity_definition" not in dir(
+        DecoratedRepository.sync_method
+    )
+    assert "__temporal_activity_definition" not in dir(
+        DecoratedRepository.base_sync_method
+    )
+
+
+def test_decorator_does_not_wrap_private_methods():
+    """Test that private async methods are not wrapped as activities."""
+
+    @temporal_repository("test.repo")
+    class DecoratedRepository(MockRepository):
+        pass
+
+    # Check that private async methods are NOT wrapped
+    assert "__temporal_activity_definition" not in dir(
+        DecoratedRepository._private_method
+    )
+    assert "__temporal_activity_definition" not in dir(
+        DecoratedRepository._private_async_method
+    )
+
+
+def test_decorated_methods_preserve_functionality():
+    """Test that decorated methods still work as expected."""
+
+    @temporal_repository("test.repo")
+    class DecoratedRepository(MockRepository):
+        pass
+
+    repo = DecoratedRepository()
+
+    # Test sync method works normally
+    result = repo.sync_method("test")
+    assert result == "sync_test"
+
+    # Test private method works normally
+    async def test_private():
+        result = await repo._private_method("test")
+        assert result == "private_test"
+
+    import asyncio
+
+    asyncio.run(test_private())
+
+
+def test_decorated_methods_preserve_metadata():
+    """Test that decorated methods preserve original method metadata."""
+
+    @temporal_repository("test.repo")
+    class DecoratedRepository(MockRepository):
+        pass
+
+    repo = DecoratedRepository()
+
+    # Check that method names are preserved
+    assert repo.process_payment.__name__ == "process_payment"
+    assert repo.get_payment.__name__ == "get_payment"
+    assert repo.refund_payment.__name__ == "refund_payment"
+
+    # Check that docstrings are preserved
+    assert "Mock payment processing method" in repo.process_payment.__doc__
+    assert "Mock get payment method" in repo.get_payment.__doc__
+    assert "Mock refund payment method" in repo.refund_payment.__doc__
+
+
+def test_activity_names_with_different_prefixes():
+    """Test different prefixes generate different activity names."""
+
+    captured_activity_names = []
+    original_activity_defn = activity.defn
+
+    def mock_activity_defn(name=None, **kwargs):
+        """Mock activity.defn to capture the activity names being created."""
+        if name:
+            captured_activity_names.append(name)
+        return original_activity_defn(name=name, **kwargs)
+
+    with patch(
+        "util.repos.temporal.decorators.activity.defn",
+        side_effect=mock_activity_defn,
+    ):
+
+        @temporal_repository("test.payment_service")
+        class PaymentServiceRepo(MockRepository):
+            pass
+
+        @temporal_repository("test.inventory_service")
+        class InventoryServiceRepo(MockRepository):
+            pass
+
+    # Verify that activity names were captured with the correct prefixes
+    payment_activities = [
+        name
+        for name in captured_activity_names
+        if name.startswith("test.payment_service")
+    ]
+    inventory_activities = [
+        name
+        for name in captured_activity_names
+        if name.startswith("test.inventory_service")
+    ]
+
+    # Should have created activities for each async method
+    expected_payment_activities = {
+        "test.payment_service.process_payment",
+        "test.payment_service.get_payment",
+        "test.payment_service.refund_payment",
+        "test.payment_service.base_async_method",
+    }
+    expected_inventory_activities = {
+        "test.inventory_service.process_payment",
+        "test.inventory_service.get_payment",
+        "test.inventory_service.refund_payment",
+        "test.inventory_service.base_async_method",
+    }
+
+    assert set(payment_activities) == expected_payment_activities
+    assert set(inventory_activities) == expected_inventory_activities
+
+    # Verify no activity names overlap between the two services
+    assert not set(payment_activities).intersection(set(inventory_activities))
+
+
+def test_decorator_handles_inheritance_correctly():
+    """Test that the decorator properly handles method resolution order."""
+
+    class ChildRepository(MockRepository):
+        async def child_method(self, value: str) -> str:
+            """Child-specific method."""
+            return f"child_{value}"
+
+        async def process_payment(self, order_id: str, amount: float) -> dict:
+            """Override parent method."""
+            return {
+                "status": "child_success",
+                "order_id": order_id,
+                "amount": amount,
+            }
+
+    @temporal_repository("test.child")
+    class DecoratedChildRepository(ChildRepository):
+        pass
+
+    # Check that all async methods are wrapped, including inherited ones
+    assert "__temporal_activity_definition" in dir(
+        DecoratedChildRepository.child_method
+    )
+    assert "__temporal_activity_definition" in dir(
+        DecoratedChildRepository.process_payment
+    )
+    assert "__temporal_activity_definition" in dir(
+        DecoratedChildRepository.base_async_method
+    )
+
+
+def test_decorator_logs_wrapped_methods():
+    """Test that the decorator logs which methods it wraps."""
+
+    with patch("util.repos.temporal.decorators.logger") as mock_logger:
+
+        @temporal_repository("test.logging")
+        class DecoratedRepository(MockRepository):
+            pass
+
+        # Check that debug logs were called for each method
+        mock_logger.debug.assert_called()
+        mock_logger.info.assert_called_once()
+
+        # Check that the info log contains the expected information
+        info_call = mock_logger.info.call_args
+        assert "Temporal repository decorator applied" in info_call[0][0]
+        assert "DecoratedRepository" in info_call[0][0]
+
+
+def test_empty_class_decorator():
+    """Test decorator behavior with a class that has no async methods."""
+
+    class EmptyRepository:
+        def sync_only(self, value: str) -> str:
+            return f"sync_{value}"
+
+    @temporal_repository("test.empty")
+    class DecoratedEmptyRepository(EmptyRepository):
+        pass
+
+    # Should still work, just no methods wrapped
+    assert "__temporal_activity_definition" not in dir(
+        DecoratedEmptyRepository.sync_only
+    )
+
+
+def test_decorator_type_preservation():
+    """Test decorator preserves class type for isinstance checks."""
+
+    @temporal_repository("test.types")
+    class DecoratedRepository(MockRepository):
+        pass
+
+    repo = DecoratedRepository()
+
+    # Check that isinstance still works
+    assert isinstance(repo, DecoratedRepository)
+    assert isinstance(repo, MockRepository)
+    assert isinstance(repo, MockBaseRepository)
+
+
+def test_multiple_decorations():
+    """Test repository can be decorated multiple times with prefixes."""
+
+    @temporal_repository("test.first")
+    class FirstDecoration(MockRepository):
+        pass
+
+    @temporal_repository("test.second")
+    class SecondDecoration(MockRepository):
+        pass
+
+    # Check that each has different activity names
+    assert "__temporal_activity_definition" in dir(
+        FirstDecoration.process_payment
+    )
+    assert "__temporal_activity_definition" in dir(
+        SecondDecoration.process_payment
+    )


### PR DESCRIPTION
# Temporal Repository Decorator Implementation

(note: moved from https://github.com/monkeypants/plays_with_temporal/pull/12 since I can't stack branches when the source branch is on my own fork).

## Overview

Adds and tests a `@temporal_repository` decorator implementation, which will enable merging layers 2 and 3 of the repository pattern by automatically wrapping repository methods as Temporal activities (next PR).

## Background

The Fun-Police Framework implements a three-layer repository pattern:

1. **Pure Backend Repository** - Direct interaction with storage (e.g., `MinioPaymentRepository`)
2. **Temporal Activity Implementation** - Wraps pure backend with `@activity.defn` decorators
3. **Workflow Proxy** - Used inside workflows for determinism

The decorator will eliminate the boilerplate code in layer 2 by automatically generating Temporal activities.

I've put it in the utils directory so we can use it in both cal and sample examples.

### Key Features

See the tests.

## Usage Example

### Before (Manual Boilerplate)

```python
class TemporalMinioPaymentRepository(PaymentRepository):
    def __init__(self, minio_payment_repo: MinioPaymentRepository):
        self._minio_payment_repo = minio_payment_repo

    @activity.defn(name="sample.order_fulfillment.payment_repo.minio.process_payment")
    async def process_payment(self, order: Order) -> PaymentOutcome:
        return await self._minio_payment_repo.process_payment(order)

    @activity.defn(name="sample.order_fulfillment.payment_repo.minio.get_payment")
    async def get_payment(self, payment_id: str) -> Optional[Payment]:
        return await self._minio_payment_repo.get_payment(payment_id)

    # ... more boilerplate for each method
```

### After (With Decorator)

```python
@temporal_repository("sample.payment_repo")
class TemporalMinioPaymentRepository(MinioPaymentRepository):
    """
    Automatically wraps all async methods as Temporal activities:
    - process_payment -> "sample.payment_repo.process_payment"
    - get_payment -> "sample.payment_repo.get_payment"
    - refund_payment -> "sample.payment_repo.refund_payment"
    """
    pass  # That's it! No boilerplate needed.
```

### Activity Naming Convention

Activity names follow the pattern: `{prefix}.{method_name}`

Examples:
- `"sample.payment_repo.process_payment"`
- `"sample.inventory_repo.reserve_items"`
- `"cal.google_calendar.create_event"`

For a minio implementatino, the prefix would be `sample.payment_repo.minio` etc.


## Benefits Achieved

### Code Reduction
- **Before**: ~20 lines of boilerplate per method
- **After**: Single `@temporal_repository("prefix")` line

### Maintenance Benefits
- **DRY Principle**: No repeated decoration code
- **Consistency**: All activities follow same naming pattern
- **Type Safety**: Full type checking support maintained

### Architecture Benefits
- **Layer Merging**: Successfully combines layers 2 and 3
- **Clean Separation**: Domain logic stays in pure repositories
- **Framework Independence**: Core repositories remain Temporal-free

## Next Steps

The decorator is ready for integration into the existing codebase. To use it:

I'll be updating in the next PR to use the decorator.

