### PR TITLE
Add note about code formatting so LLM will not exceed line limits.

### DIFF
--- a/fun-police/formatting.org
+++ b/fun-police/formatting.org
@@ -1,0 +1,53 @@
+#+TITLE: Code Formatting Standards
+#+STARTUP: overview
+
+* Code Formatting Standards
+
+** Line Length Limit
+
+*78 characters maximum* - enforced by Black and Ruff
+
+Configuration in `pyproject.toml`:
+#+BEGIN_SRC toml
+[tool.black]
+line-length = 78
+
+[tool.ruff]
+line-length = 78
+#+END_SRC
+
+** Handling Long Lines
+
+1. *Extract variables*:
+   #+BEGIN_SRC python
+   args = (argument1, argument2, argument3)
+   result = some_long_function_name(*args)
+   #+END_SRC
+
+2. *Use parentheses for line breaks*:
+   #+BEGIN_SRC python
+   message = (
+       "Long message that exceeds line limit "
+       "split across multiple lines"
+   )
+   #+END_SRC
+
+3. *Logging messages*:
+   #+BEGIN_SRC python
+   logger.info(
+       "Operation completed successfully",
+       extra={"entity_id": entity.id},
+   )
+   #+END_SRC
+
+*Important*: Don't use `"name"` in logging `extra` - it conflicts with LogRecord.
+Use `"spec_name"`, `"entity_name"`, etc.
+
+** Enforcement
+
+- `make format` - Auto-format code
+- `make quality-fast` - Validate formatting
+- All enforced automatically in CI/CD
+
+*Principle*: If you consistently hit line length limits,
+consider whether your code violates Single Responsibility Principle.

--- a/fun-police/systemPatterns.org
+++ b/fun-police/systemPatterns.org
@@ -17,6 +17,9 @@ By eliminating architectural decision-making during implementation,
 developers can focus their creative energy on solving business problems
 rather than debating patterns.
 
+*Note*: Code formatting standards (line length, style rules) are defined
+separately in =fun-police/formatting.org= and enforced via =pyproject.toml=.
+
 ** Architecture Overview
 
 The system implements Clean Architecture with Hexagonal Architecture principles,
@@ -27,6 +30,10 @@ while maintaining framework independence in the core domain.
 All implementations must follow these patterns exactly -
 innovation on architecture is explicitly prohibited
 to prevent technical debt and maintain system coherence.
+
+*Related Documentation*:
+- Code formatting standards: =fun-police/formatting.org=
+- Tooling configuration: =pyproject.toml=
 
 ** Core Architectural Patterns
 


### PR DESCRIPTION
Small PR to fix a time-waster: each PR I create has to have a good few minutes of the agent fixing all the long lines it has created/generated. With this change, the 78-char line limit should be observed from the start (when I ask the agent to read systemPatterns.org and related docs).