### PR TITLE
Add initial stubbed use-case with decorator to avoid boilerplate.

### DIFF
--- a/julee_example/repositories/__init__.py
+++ b/julee_example/repositories/__init__.py
@@ -1,0 +1,17 @@
+"""
+Repository protocols for julee_example domain.
+
+This module exports all repository protocol interfaces for the Capture,
+Extract, Assemble, Publish workflow, following the Clean Architecture
+patterns established in the Fun-Police framework.
+"""
+
+from .document import DocumentRepository
+from .assembly import AssemblyRepository
+from .assembly_specification import AssemblySpecificationRepository
+
+__all__ = [
+    "DocumentRepository",
+    "AssemblyRepository",
+    "AssemblySpecificationRepository",
+]

--- a/julee_example/use_cases/__init__.py
+++ b/julee_example/use_cases/__init__.py
@@ -1,0 +1,7 @@
+"""
+Use cases for julee_example domain.
+
+This package contains use case classes that orchestrate business logic
+for the Capture, Extract, Assemble, Publish workflow while remaining
+framework-agnostic following Clean Architecture principles.
+"""

--- a/julee_example/use_cases/assemble_data.py
+++ b/julee_example/use_cases/assemble_data.py
@@ -1,0 +1,149 @@
+"""
+Use case logic for data assembly within the Capture, Extract, Assemble,
+Publish workflow.
+
+This module contains use case classes that orchestrate business logic while
+remaining framework-agnostic. Dependencies are injected via repository
+instances following the Clean Architecture principles.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from julee_example.domain import Assembly, AssemblyStatus
+from julee_example.repositories import (
+    DocumentRepository,
+    AssemblyRepository,
+    AssemblySpecificationRepository,
+)
+from sample.validation import ensure_repository_protocol
+from .decorators import try_use_case_step
+
+logger = logging.getLogger(__name__)
+
+
+class AssembleDataUseCase:
+    """
+    Use case for assembling documents according to specifications.
+
+    This class orchestrates the business logic for the "Assemble" phase
+    of the Capture, Extract, Assemble, Publish workflow while remaining
+    framework-agnostic. It depends only on repository protocols, not
+    concrete implementations.
+
+    In workflow contexts, this use case is called from workflow code with
+    repository stubs that delegate to Temporal activities for durability.
+    The use case remains completely unaware of whether it's running in a
+    workflow context or a simple async context - it just calls repository
+    methods and expects them to work correctly.
+
+    Architectural Notes:
+    - This class contains pure business logic with no framework dependencies
+    - Repository dependencies are injected via constructor
+      (dependency inversion)
+    - All error handling and compensation logic is contained here
+    - The use case works with domain objects exclusively
+    - Deterministic execution is guaranteed by avoiding
+      non-deterministic operations
+    """
+
+    def __init__(
+        self,
+        document_repo: DocumentRepository,
+        assembly_repo: AssemblyRepository,
+        assembly_specification_repo: AssemblySpecificationRepository,
+    ) -> None:
+        """Initialize data assembly use case.
+
+        Args:
+            document_repo: Repository for document operations
+            assembly_repo: Repository for assembly operations
+            assembly_specification_repo: Repository for assembly
+                specification operations
+
+        Note:
+            The repositories passed here may be concrete implementations
+            (for testing or direct execution) or workflow stubs (for
+            Temporal workflow execution). The use case doesn't know or care
+            which - it just calls the methods defined in the protocols.
+
+            Repositories are validated at construction time to catch
+            configuration errors early in the application lifecycle.
+        """
+        # Validate at construction time for early error detection
+        self.document_repo = ensure_repository_protocol(
+            document_repo, DocumentRepository  # type: ignore[type-abstract]
+        )
+        self.assembly_repo = ensure_repository_protocol(
+            assembly_repo, AssemblyRepository  # type: ignore[type-abstract]
+        )
+        self.assembly_specification_repo = ensure_repository_protocol(
+            assembly_specification_repo, AssemblySpecificationRepository  # type: ignore[type-abstract]
+        )
+
+    async def assemble_data(
+        self,
+        document_id: str,
+        assembly_specification_id: str,
+    ) -> Assembly:
+        """
+        Assemble a document according to its specification and create a new
+        assembly.
+
+        This method orchestrates the core assembly workflow:
+        1. Generates a unique assembly ID
+        2. Retrieves the assembly specification
+        3. Retrieves the source document
+        4. Processes the document according to the specification
+        5. Creates and returns the new assembly
+
+        Args:
+            document_id: ID of the document to assemble
+            assembly_specification_id: ID of the specification to use
+
+        Returns:
+            New Assembly with the assembled document iteration
+
+        Raises:
+            ValueError: If required entities are not found or invalid
+            RuntimeError: If assembly processing fails
+        """
+        logger.debug(
+            "Starting data assembly use case",
+            extra={
+                "document_id": document_id,
+                "assembly_specification_id": assembly_specification_id,
+            },
+        )
+
+        # Step 1: Generate unique assembly ID
+        assembly_id = await self._generate_assembly_id(
+            document_id, assembly_specification_id
+        )
+
+        # TODO: Implement the assembly logic following the saga pattern
+        # This should:
+        # 1. Validate all required entities exist
+        # 2. Process the document according to the specification
+        # 3. Add the iteration to the assembly
+        # 4. Handle any compensation if needed
+
+        # For now, return an empty Assembly with the generated ID
+        assembly = Assembly(
+            assembly_id=assembly_id,
+            assembly_specification_id=assembly_specification_id,
+            input_document_id=document_id,
+            status=AssemblyStatus.PENDING,
+            iterations=[],
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        return assembly
+
+    @try_use_case_step("assembly_id_generation")
+    async def _generate_assembly_id(
+        self, document_id: str, assembly_specification_id: str
+    ) -> str:
+        """Generate a unique assembly ID with consistent error handling."""
+        return await self.assembly_repo.generate_id()

--- a/julee_example/use_cases/decorators.py
+++ b/julee_example/use_cases/decorators.py
@@ -1,0 +1,107 @@
+"""
+Decorators for use case step error handling and logging.
+
+This module provides decorators that implement consistent error handling
+and logging patterns across all use cases in the julee_example domain,
+following the patterns established in the sample use cases.
+"""
+
+import logging
+from functools import wraps
+from typing import Any, Callable, Dict, Optional, TypeVar, Awaitable
+
+logger = logging.getLogger(__name__)
+
+F = TypeVar("F", bound=Callable[..., Awaitable[Any]])
+
+
+def try_use_case_step(
+    step_name: str,
+    extra_context: Optional[Dict[str, Any]] = None,
+) -> Callable[[F], F]:
+    """
+    Decorator that wraps use case steps with consistent error handling and
+    logging.
+
+    This decorator provides the same error handling and logging pattern used
+    in the sample use cases, eliminating boilerplate and ensuring consistency
+    across all use case implementations.
+
+    Args:
+        step_name: Name of the step (e.g., "assembly_id_generation")
+        extra_context: Optional additional context to include in all log
+            messages
+
+    Returns:
+        Decorated function with consistent error handling and logging
+
+    Example:
+        >>> @try_use_case_step(
+        ...     "assembly_id_generation", {"document_id": "doc-123"}
+        ... )
+        >>> async def generate_assembly_id(self) -> str:
+        ...     return await self.assembly_repo.generate_id()
+    """
+
+    def decorator(func: F) -> F:
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            # Build base logging context
+            log_context = {
+                "debug_step": f"before_{step_name}",
+            }
+            if extra_context:
+                log_context.update(extra_context)
+
+            # Pre-step logging
+            logger.debug(
+                f"About to {step_name}",
+                extra=log_context,
+            )
+
+            try:
+                # Execute the wrapped function
+                result = await func(*args, **kwargs)
+
+                # Success logging with result information
+                success_context = {
+                    "debug_step": f"{step_name}_success",
+                }
+                if extra_context:
+                    success_context.update(extra_context)
+
+                # Add result to logging context if it's a simple type
+                if isinstance(result, str):
+                    success_context["result"] = result
+                elif hasattr(result, "id"):
+                    success_context["result_id"] = result.id
+                elif hasattr(result, "__dict__"):
+                    # For complex objects, just log the type
+                    success_context["result_type"] = type(result).__name__
+
+                logger.debug(
+                    f"{step_name} completed successfully",
+                    extra=success_context,
+                )
+
+                return result
+
+            except Exception as e:
+                # Error logging
+                error_context = {
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                    "debug_step": f"{step_name}_failed",
+                }
+                if extra_context:
+                    error_context.update(extra_context)
+
+                logger.error(
+                    f"Failed to {step_name}",
+                    extra=error_context,
+                )
+                raise
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator

--- a/julee_example/use_cases/tests/__init__.py
+++ b/julee_example/use_cases/tests/__init__.py
@@ -1,0 +1,7 @@
+"""
+Tests for julee_example use cases.
+
+This package contains test modules for all use cases in the julee_example
+domain, following the Clean Architecture testing patterns established in
+the sample application.
+"""

--- a/julee_example/use_cases/tests/test_assemble_data.py
+++ b/julee_example/use_cases/tests/test_assemble_data.py
@@ -1,0 +1,115 @@
+"""
+Tests for AssembleDataUseCase.
+
+This module provides tests for the data assembly use case, ensuring proper
+business logic execution and repository interaction patterns following
+the Clean Architecture principles.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from datetime import datetime
+
+from julee_example.use_cases.assemble_data import AssembleDataUseCase
+from julee_example.domain import Assembly
+from julee_example.repositories import (
+    DocumentRepository,
+    AssemblyRepository,
+    AssemblySpecificationRepository,
+)
+
+
+class TestAssembleDataUseCase:
+    """Test cases for AssembleDataUseCase business logic."""
+
+    @pytest.fixture
+    def mock_document_repo(self) -> DocumentRepository:
+        """Create a mock DocumentRepository for testing."""
+        mock = MagicMock(spec=DocumentRepository)
+        return mock
+
+    @pytest.fixture
+    def mock_assembly_repo(self) -> AssemblyRepository:
+        """Create a mock AssemblyRepository for testing."""
+        mock = MagicMock(spec=AssemblyRepository)
+        return mock
+
+    @pytest.fixture
+    def mock_assembly_specification_repo(
+        self,
+    ) -> AssemblySpecificationRepository:
+        """Create a mock AssemblySpecificationRepository for testing."""
+        mock = MagicMock(spec=AssemblySpecificationRepository)
+        return mock
+
+    @pytest.fixture
+    def use_case(
+        self,
+        mock_document_repo: DocumentRepository,
+        mock_assembly_repo: AssemblyRepository,
+        mock_assembly_specification_repo: AssemblySpecificationRepository,
+    ) -> AssembleDataUseCase:
+        """Create AssembleDataUseCase with mocked dependencies."""
+        return AssembleDataUseCase(
+            document_repo=mock_document_repo,
+            assembly_repo=mock_assembly_repo,
+            assembly_specification_repo=mock_assembly_specification_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_assemble_data_generates_assembly_id(
+        self,
+        use_case: AssembleDataUseCase,
+        mock_assembly_repo: AssemblyRepository,
+    ) -> None:
+        """Test that assemble_data generates a unique assembly ID."""
+        # Arrange
+        expected_assembly_id = "assembly-12345"
+        document_id = "doc-456"
+        assembly_specification_id = "spec-789"
+
+        mock_assembly_repo.generate_id = AsyncMock(  # type: ignore[method-assign]
+            return_value=expected_assembly_id
+        )
+
+        # Act
+        result = await use_case.assemble_data(
+            document_id=document_id,
+            assembly_specification_id=assembly_specification_id,
+        )
+
+        # Assert
+        mock_assembly_repo.generate_id.assert_called_once()
+        assert isinstance(result, Assembly)
+        assert result.assembly_id == expected_assembly_id
+        assert result.assembly_specification_id == assembly_specification_id
+        assert result.input_document_id == document_id
+        from julee_example.domain import AssemblyStatus
+
+        assert result.status == AssemblyStatus.PENDING
+        assert result.iterations == []
+        assert isinstance(result.created_at, datetime)
+        assert isinstance(result.updated_at, datetime)
+
+    @pytest.mark.asyncio
+    async def test_assemble_data_propagates_id_generation_error(
+        self,
+        use_case: AssembleDataUseCase,
+        mock_assembly_repo: AssemblyRepository,
+    ) -> None:
+        """Test that ID generation errors are properly propagated."""
+        # Arrange
+        document_id = "doc-456"
+        assembly_specification_id = "spec-789"
+        expected_error = RuntimeError("ID generation failed")
+
+        mock_assembly_repo.generate_id = AsyncMock(side_effect=expected_error)  # type: ignore[method-assign]
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match="ID generation failed"):
+            await use_case.assemble_data(
+                document_id=document_id,
+                assembly_specification_id=assembly_specification_id,
+            )
+
+        mock_assembly_repo.generate_id.assert_called_once()


### PR DESCRIPTION
This PR adds a stubbed `assemble_data` use-case method (it currently only generates an assembly id and returns an assembly with that id, without any iterations) to demonstrate two things:

1. The use of a decorator `try_use_case_step` to avoid all the logging/exception boilerplate in the existing sample use cases, and
2. Demonstrate how testing a use-case with a bunch of mocks gets ugly fast - the next PR will simply add memory implementations of the repositories for use in tests, to then show how much simpler (hopefully) that simple test can be.