### PR TITLE
Adds KnowledgeServiceConfig domain and repo model as well as service

### DIFF
--- a/julee_example/domain/__init__.py
+++ b/julee_example/domain/__init__.py
@@ -6,6 +6,7 @@ from .assembly_specification import (
     KnowledgeServiceQuery,
 )
 from .assembly import Assembly, AssemblyStatus, AssemblyIteration
+from .knowledge_service_config import KnowledgeServiceConfig
 
 __all__ = [
     "Document",
@@ -17,4 +18,5 @@ __all__ = [
     "Assembly",
     "AssemblyStatus",
     "AssemblyIteration",
+    "KnowledgeServiceConfig",
 ]

--- a/julee_example/domain/knowledge_service_config/__init__.py
+++ b/julee_example/domain/knowledge_service_config/__init__.py
@@ -1,0 +1,17 @@
+"""
+Knowledge Service domain models for julee_example domain.
+
+This module exports domain models for knowledge services in the Capture,
+Extract, Assemble, Publish workflow. Knowledge services represent external
+AI/ML services that can store documents and execute queries against them.
+"""
+
+from .knowledge_service_config import (
+    KnowledgeServiceConfig,
+    ServiceApi,
+)
+
+__all__ = [
+    "KnowledgeServiceConfig",
+    "ServiceApi",
+]

--- a/julee_example/domain/knowledge_service_config/knowledge_service_config.py
+++ b/julee_example/domain/knowledge_service_config/knowledge_service_config.py
@@ -1,0 +1,79 @@
+"""
+KnowledgeService domain models for the Capture, Extract, Assemble,
+Publish workflow.
+
+This module contains the KnowledgeService domain object that represents
+knowledge services in the CEAP workflow system.
+
+A KnowledgeService defines a service that can store documents and execute
+queries against them. It acts as an interface to external AI/ML services
+that can analyze and extract information from documents.
+
+All domain models use Pydantic BaseModel for validation, serialization,
+and type safety, following the patterns established in the sample project.
+"""
+
+from pydantic import BaseModel, Field, field_validator
+from typing import Optional
+from datetime import datetime, timezone
+from enum import Enum
+
+
+class ServiceApi(str, Enum):
+    """Supported knowledge service APIs."""
+
+    ANTHROPIC = "anthropic"
+
+
+class KnowledgeServiceConfig(BaseModel):
+    """Knowledge service configuration that defines how to interact with
+    an external knowledge/AI service.
+
+    A KnowledgeServiceConfig represents a service endpoint that can store
+    documents and execute queries against them. This could be an AI service,
+    vector database, search engine, or any other service that can analyze
+    documents and answer questions about them.
+    """
+
+    # Core service identification
+    knowledge_service_id: str = Field(
+        description="Unique identifier for this knowledge service"
+    )
+    name: str = Field(
+        description="Human-readable name for the knowledge service"
+    )
+    description: str = Field(
+        description="Description of what this knowledge service does"
+    )
+    service_api: ServiceApi = Field(
+        description="The external API/service this knowledge service uses"
+    )
+
+    # Timestamps
+    created_at: Optional[datetime] = Field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Optional[datetime] = Field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+
+    @field_validator("knowledge_service_id")
+    @classmethod
+    def knowledge_service_id_must_not_be_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("Knowledge service ID cannot be empty")
+        return v.strip()
+
+    @field_validator("name")
+    @classmethod
+    def name_must_not_be_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("Knowledge service name cannot be empty")
+        return v.strip()
+
+    @field_validator("description")
+    @classmethod
+    def description_must_not_be_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("Knowledge service description cannot be empty")
+        return v.strip()

--- a/julee_example/domain/knowledge_service_config/knowledge_service_config.py
+++ b/julee_example/domain/knowledge_service_config/knowledge_service_config.py
@@ -77,3 +77,10 @@ class KnowledgeServiceConfig(BaseModel):
         if not v or not v.strip():
             raise ValueError("Knowledge service description cannot be empty")
         return v.strip()
+
+    @field_validator("service_api")
+    @classmethod
+    def service_api_must_be_valid(cls, v: ServiceApi) -> ServiceApi:
+        if v not in ServiceApi:
+            raise ValueError(f"Invalid service API: {v}. Must be one of {list(ServiceApi)}")
+        return v

--- a/julee_example/domain/knowledge_service_config/knowledge_service_config.py
+++ b/julee_example/domain/knowledge_service_config/knowledge_service_config.py
@@ -82,5 +82,7 @@ class KnowledgeServiceConfig(BaseModel):
     @classmethod
     def service_api_must_be_valid(cls, v: ServiceApi) -> ServiceApi:
         if v not in ServiceApi:
-            raise ValueError(f"Invalid service API: {v}. Must be one of {list(ServiceApi)}")
+            raise ValueError(
+                f"Invalid service API: {v}. Must be one of {list(ServiceApi)}"
+            )
         return v

--- a/julee_example/repositories/__init__.py
+++ b/julee_example/repositories/__init__.py
@@ -9,9 +9,11 @@ patterns established in the Fun-Police framework.
 from .document import DocumentRepository
 from .assembly import AssemblyRepository
 from .assembly_specification import AssemblySpecificationRepository
+from .knowledge_service_config import KnowledgeServiceConfigRepository
 
 __all__ = [
     "DocumentRepository",
     "AssemblyRepository",
     "AssemblySpecificationRepository",
+    "KnowledgeServiceConfigRepository",
 ]

--- a/julee_example/repositories/knowledge_service_config.py
+++ b/julee_example/repositories/knowledge_service_config.py
@@ -1,0 +1,98 @@
+"""
+KnowledgeServiceConfig repository interface defined as Protocol for the
+Capture, Extract, Assemble, Publish workflow.
+
+This module defines the knowledge service configuration repository protocol.
+The repository works with KnowledgeService domain objects for metadata
+persistence only. External service operations are handled by the service
+layer.
+
+All repository operations follow the same principles as the sample
+repositories:
+
+- **Idempotency**: All methods are designed to be idempotent and safe for
+  retry. Multiple calls with the same parameters will produce the same
+  result without unintended side effects.
+
+- **Workflow Safety**: All operations are safe to call from deterministic
+  workflow contexts. Non-deterministic operations (like ID generation) are
+  explicitly delegated to activities.
+
+- **Domain Objects**: Methods accept and return domain objects or primitives,
+  never framework-specific types. Results are returned as structured domain
+  objects.
+
+- **External Service Integration**: Repository implementations handle the
+  complexities of integrating with external knowledge services while
+  maintaining a clean, consistent interface.
+
+In Temporal workflow contexts, these protocols are implemented by workflow
+stubs that delegate to activities for durability and proper error handling.
+"""
+
+from typing import Protocol, Optional, runtime_checkable
+from julee_example.domain import KnowledgeServiceConfig
+
+
+@runtime_checkable
+class KnowledgeServiceConfigRepository(Protocol):
+    """Handles knowledge service configuration persistence.
+
+    This repository manages knowledge service metadata and configuration
+    storage within the Capture, Extract, Assemble, Publish workflow.
+    External service operations are handled separately by the service layer.
+    """
+
+    async def get(
+        self, knowledge_service_id: str
+    ) -> Optional[KnowledgeServiceConfig]:
+        """Retrieve a knowledge service configuration by ID.
+
+        Args:
+            knowledge_service_id: Unique knowledge service identifier
+
+        Returns:
+            KnowledgeServiceConfig object if found, None otherwise
+
+        Implementation Notes:
+        - Must be idempotent: multiple calls return same result
+        - Should handle missing services gracefully (return None)
+        - Must load complete service configuration
+        """
+        ...
+
+    async def save(self, knowledge_service: KnowledgeServiceConfig) -> None:
+        """Save a knowledge service configuration.
+
+        Args:
+            knowledge_service: Complete KnowledgeServiceConfig to save
+
+        Implementation Notes:
+        - Must be idempotent: saving same service state is safe
+        - Should update the updated_at timestamp
+        - Must save complete service configuration
+        - Handles both new services and updates to existing ones
+        """
+        ...
+
+    async def generate_id(self) -> str:
+        """Generate a unique knowledge service identifier.
+
+        This operation is non-deterministic and must be called from
+        workflow activities, not directly from workflow code.
+
+        Returns:
+            Unique knowledge service ID string
+
+        Implementation Notes:
+        - Must generate globally unique identifiers
+        - May use UUIDs, database sequences, or distributed ID generators
+        - Should be fast and reliable
+        - Failure here should be rare but handled gracefully
+
+        Workflow Context:
+        In Temporal workflows, this method is implemented as an activity
+        to ensure the generated ID is durably stored and consistent
+        across workflow replays.
+        """
+        ...

--- a/julee_example/services/__init__.py
+++ b/julee_example/services/__init__.py
@@ -1,0 +1,22 @@
+"""
+Services for julee_example domain.
+
+This module provides service classes and factory functions for interacting
+with external services in the Capture, Extract, Assemble, Publish workflow.
+
+The services layer handles external integrations while the repository layer
+handles local metadata persistence. Services are organized by service type
+into submodules, each with their own protocols and implementations.
+"""
+
+# Re-export knowledge service components
+from .knowledge_service import (
+    KnowledgeService,
+    knowledge_service_factory,
+)
+
+__all__ = [
+    # Knowledge Service
+    "KnowledgeService",
+    "knowledge_service_factory",
+]

--- a/julee_example/services/knowledge_service/__init__.py
+++ b/julee_example/services/knowledge_service/__init__.py
@@ -68,7 +68,7 @@ def knowledge_service_factory(
 
     Example:
         >>> from julee_example.domain import KnowledgeServiceConfig
-        >>> from julee_example.domain.knowledge_service import ServiceApi
+        >>> from julee_example.domain.knowledge_service_config import ServiceApi
         >>> config = KnowledgeServiceConfig(
         ...     knowledge_service_id="ks-123",
         ...     name="My Anthropic Service",

--- a/julee_example/services/knowledge_service/__init__.py
+++ b/julee_example/services/knowledge_service/__init__.py
@@ -23,6 +23,26 @@ from julee_example.domain.knowledge_service_config import ServiceApi
 logger = logging.getLogger(__name__)
 
 
+def ensure_knowledge_service(service: object) -> KnowledgeService:
+    """Ensure an object satisfies the KnowledgeService protocol.
+
+    Args:
+        service: The service implementation to validate
+
+    Returns:
+        The validated service (type checker knows it satisfies KnowledgeService)
+
+    Raises:
+        TypeError: If the service doesn't satisfy the protocol
+    """
+    if not isinstance(service, KnowledgeService):
+        raise TypeError(
+            f"Service {type(service).__name__} does not satisfy KnowledgeService protocol"
+        )
+
+    return service
+
+
 def knowledge_service_factory(
     knowledge_service_config: "KnowledgeServiceConfig",
 ) -> KnowledgeService:
@@ -74,6 +94,9 @@ def knowledge_service_factory(
             f"Unsupported service API: {knowledge_service_config.service_api}"
         )
 
+    # Validate that the service satisfies the protocol
+    validated_service = ensure_knowledge_service(service)
+
     logger.info(
         "KnowledgeService created successfully",
         extra={
@@ -81,16 +104,17 @@ def knowledge_service_factory(
                 knowledge_service_config.knowledge_service_id
             ),
             "service_api": knowledge_service_config.service_api.value,
-            "implementation": type(service).__name__,
+            "implementation": type(validated_service).__name__,
         },
     )
 
-    return service
+    return validated_service
 
 
 __all__ = [
     "KnowledgeService",
     "knowledge_service_factory",
+    "ensure_knowledge_service",
     "QueryResult",
     "FileRegistrationResult",
 ]

--- a/julee_example/services/knowledge_service/__init__.py
+++ b/julee_example/services/knowledge_service/__init__.py
@@ -1,0 +1,96 @@
+"""
+Knowledge Service module for julee_example domain.
+
+This module provides the KnowledgeService protocol and factory function for
+creating configured knowledge service instances. The factory routes to the
+appropriate implementation based on the service_api configuration.
+"""
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from julee_example.domain import KnowledgeServiceConfig
+
+from .knowledge_service import (
+    KnowledgeService,
+    QueryResult,
+    FileRegistrationResult,
+)
+from .anthropic import AnthropicKnowledgeService
+from julee_example.domain.knowledge_service_config import ServiceApi
+
+logger = logging.getLogger(__name__)
+
+
+def knowledge_service_factory(
+    knowledge_service_config: "KnowledgeServiceConfig",
+) -> KnowledgeService:
+    """Create a configured KnowledgeService instance.
+
+    This factory function takes a KnowledgeServiceConfig domain object
+    (containing metadata and service_api information) and returns a properly
+    configured KnowledgeService implementation that can handle external
+    operations.
+
+    Args:
+        knowledge_service_config: KnowledgeServiceConfig domain object with
+                                 configuration and API information
+
+    Returns:
+        Configured KnowledgeService implementation ready for external
+        operations
+
+    Raises:
+        ValueError: If the service_api is not supported
+
+    Example:
+        >>> from julee_example.domain import KnowledgeServiceConfig
+        >>> from julee_example.domain.knowledge_service import ServiceApi
+        >>> config = KnowledgeServiceConfig(
+        ...     knowledge_service_id="ks-123",
+        ...     name="My Anthropic Service",
+        ...     description="Anthropic-powered document analysis",
+        ...     service_api=ServiceApi.ANTHROPIC
+        ... )
+        >>> service = knowledge_service_factory(config)
+        >>> result = await service.register_file("doc-456")
+    """
+    logger.debug(
+        "Creating KnowledgeService via factory",
+        extra={
+            "knowledge_service_id": (
+                knowledge_service_config.knowledge_service_id
+            ),
+            "service_api": knowledge_service_config.service_api.value,
+        },
+    )
+
+    # Route to appropriate implementation based on service_api
+    if knowledge_service_config.service_api == ServiceApi.ANTHROPIC:
+        service = AnthropicKnowledgeService(knowledge_service_config)
+    else:
+        raise ValueError(
+            f"Unsupported service API: {knowledge_service_config.service_api}"
+        )
+
+    logger.info(
+        "KnowledgeService created successfully",
+        extra={
+            "knowledge_service_id": (
+                knowledge_service_config.knowledge_service_id
+            ),
+            "service_api": knowledge_service_config.service_api.value,
+            "implementation": type(service).__name__,
+        },
+    )
+
+    return service
+
+
+__all__ = [
+    "KnowledgeService",
+    "knowledge_service_factory",
+    "QueryResult",
+    "FileRegistrationResult",
+]

--- a/julee_example/services/knowledge_service/__init__.py
+++ b/julee_example/services/knowledge_service/__init__.py
@@ -68,7 +68,9 @@ def knowledge_service_factory(
 
     Example:
         >>> from julee_example.domain import KnowledgeServiceConfig
-        >>> from julee_example.domain.knowledge_service_config import ServiceApi
+        >>> from julee_example.domain.knowledge_service_config import (
+        ...     ServiceApi
+        ... )
         >>> config = KnowledgeServiceConfig(
         ...     knowledge_service_id="ks-123",
         ...     name="My Anthropic Service",

--- a/julee_example/services/knowledge_service/__init__.py
+++ b/julee_example/services/knowledge_service/__init__.py
@@ -30,14 +30,16 @@ def ensure_knowledge_service(service: object) -> KnowledgeService:
         service: The service implementation to validate
 
     Returns:
-        The validated service (type checker knows it satisfies KnowledgeService)
+        The validated service (type checker knows it satisfies
+        KnowledgeService)
 
     Raises:
         TypeError: If the service doesn't satisfy the protocol
     """
     if not isinstance(service, KnowledgeService):
         raise TypeError(
-            f"Service {type(service).__name__} does not satisfy KnowledgeService protocol"
+            f"Service {type(service).__name__} does not satisfy "
+            f"KnowledgeService protocol"
         )
 
     return service

--- a/julee_example/services/knowledge_service/anthropic/__init__.py
+++ b/julee_example/services/knowledge_service/anthropic/__init__.py
@@ -1,0 +1,12 @@
+"""
+Anthropic service implementations for julee_example domain.
+
+This module exports Anthropic-specific implementations of service protocols
+for the Capture, Extract, Assemble, Publish workflow.
+"""
+
+from .knowledge_service import AnthropicKnowledgeService
+
+__all__ = [
+    "AnthropicKnowledgeService",
+]

--- a/julee_example/services/knowledge_service/anthropic/knowledge_service.py
+++ b/julee_example/services/knowledge_service/anthropic/knowledge_service.py
@@ -1,0 +1,156 @@
+"""
+Anthropic implementation of KnowledgeService for the Capture, Extract,
+Assemble, Publish workflow.
+
+This module provides the Anthropic-specific implementation of the
+KnowledgeService protocol. It handles interactions with Anthropic's API
+for document registration and query execution.
+"""
+
+import logging
+from typing import Optional, List
+from datetime import datetime, timezone
+
+from julee_example.domain import KnowledgeServiceConfig
+from ..knowledge_service import (
+    KnowledgeService,
+    QueryResult,
+    FileRegistrationResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AnthropicKnowledgeService(KnowledgeService):
+    """
+    Anthropic implementation of the KnowledgeService protocol.
+
+    This class handles interactions with Anthropic's API for document
+    registration and query execution. It implements the KnowledgeService
+    protocol with Anthropic-specific logic.
+    """
+
+    def __init__(self, config: KnowledgeServiceConfig) -> None:
+        """Initialize Anthropic knowledge service with configuration.
+
+        Args:
+            config: KnowledgeServiceConfig domain object containing metadata
+                   and service configuration
+        """
+        logger.debug(
+            "Initializing AnthropicKnowledgeService",
+            extra={
+                "knowledge_service_id": config.knowledge_service_id,
+                "service_name": config.name,
+            },
+        )
+
+        self.config = config
+
+    async def register_file(self, document_id: str) -> FileRegistrationResult:
+        """Register a document file with Anthropic.
+
+        Args:
+            document_id: ID of the document to register
+
+        Returns:
+            FileRegistrationResult with Anthropic-specific details
+        """
+        logger.debug(
+            "Registering file with Anthropic",
+            extra={
+                "knowledge_service_id": self.config.knowledge_service_id,
+                "document_id": document_id,
+            },
+        )
+
+        # TODO: Implement Anthropic-specific file registration
+        # This would involve:
+        # 1. Getting document content from document repository
+        # 2. Uploading to Anthropic API (when available)
+        # 3. Storing the Anthropic file ID mapping
+        # 4. Handling Anthropic-specific response format
+
+        # For now, return a stub result
+        anthropic_file_id = (
+            f"anthropic_{document_id}_{int(datetime.now().timestamp())}"
+        )
+
+        result = FileRegistrationResult(
+            document_id=document_id,
+            knowledge_service_file_id=anthropic_file_id,
+            registration_metadata={
+                "service": "anthropic",
+                "registered_via": "api_stub",
+            },
+            created_at=datetime.now(timezone.utc),
+        )
+
+        logger.info(
+            "File registered with Anthropic (stub)",
+            extra={
+                "knowledge_service_id": self.config.knowledge_service_id,
+                "document_id": document_id,
+                "anthropic_file_id": anthropic_file_id,
+            },
+        )
+
+        return result
+
+    async def execute_query(
+        self,
+        query_text: str,
+        document_ids: Optional[List[str]] = None,
+    ) -> QueryResult:
+        """Execute a query against Anthropic.
+
+        Args:
+            query_text: The query to execute
+            document_ids: Optional list of document IDs to scope query to
+
+        Returns:
+            QueryResult with Anthropic query results
+        """
+        logger.debug(
+            "Executing query with Anthropic",
+            extra={
+                "knowledge_service_id": self.config.knowledge_service_id,
+                "query_text": query_text,
+                "document_count": len(document_ids) if document_ids else 0,
+            },
+        )
+
+        # TODO: Implement Anthropic-specific query execution
+        # This would involve:
+        # 1. Translating document_ids to Anthropic file IDs
+        # 2. Constructing Anthropic API request with context
+        # 3. Executing query against Anthropic API
+        # 4. Processing Anthropic response format
+        # 5. Structuring results into QueryResult format
+
+        # For now, return a stub result
+        query_id = f"anthropic_query_{int(datetime.now().timestamp())}"
+
+        result = QueryResult(
+            query_id=query_id,
+            query_text=query_text,
+            result_data={
+                "response": "This is a stub response from Anthropic",
+                "confidence": 0.95,
+                "sources": document_ids or [],
+                "service": "anthropic",
+            },
+            execution_time_ms=250,  # Stub execution time
+            created_at=datetime.now(timezone.utc),
+        )
+
+        logger.info(
+            "Query executed with Anthropic (stub)",
+            extra={
+                "knowledge_service_id": self.config.knowledge_service_id,
+                "query_id": query_id,
+                "execution_time_ms": result.execution_time_ms,
+            },
+        )
+
+        return result

--- a/julee_example/services/knowledge_service/knowledge_service.py
+++ b/julee_example/services/knowledge_service/knowledge_service.py
@@ -1,0 +1,132 @@
+"""
+KnowledgeService protocol for external service operations in the Capture,
+Extract, Assemble, Publish workflow.
+
+This module defines the KnowledgeService protocol that handles interactions
+with external knowledge services, including document registration and query
+execution. This protocol is separate from the repository layer which only
+handles local metadata persistence.
+
+Concrete implementations of this protocol are provided for different external
+services (Anthropic, OpenAI, etc.) and are created via factory functions.
+"""
+
+from typing import Protocol, Optional, List, runtime_checkable, Dict, Any
+from datetime import datetime, timezone
+from pydantic import BaseModel, Field
+
+
+class QueryResult(BaseModel):
+    """Result of a knowledge service query execution."""
+
+    query_id: str = Field(
+        description="Unique identifier for this query execution"
+    )
+    query_text: str = Field(
+        description="The original query text that was executed"
+    )
+    result_data: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="The structured result data from the query",
+    )
+    execution_time_ms: Optional[int] = Field(
+        default=None,
+        description="Time taken to execute the query in milliseconds",
+    )
+    created_at: Optional[datetime] = Field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+
+
+class FileRegistrationResult(BaseModel):
+    """Result of registering a file with a knowledge service."""
+
+    document_id: str = Field(
+        description="The original document ID from our system"
+    )
+    knowledge_service_file_id: str = Field(
+        description="The file identifier assigned by the knowledge service"
+    )
+    registration_metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional metadata from the registration process",
+    )
+    created_at: Optional[datetime] = Field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+
+
+@runtime_checkable
+class KnowledgeService(Protocol):
+    """
+    Protocol for interacting with external knowledge services.
+
+    This protocol defines the interface for external operations that were
+    moved out of the repository layer. Implementations handle the specifics
+    of different knowledge service APIs (Anthropic, OpenAI, etc.).
+    """
+
+    async def register_file(self, document_id: str) -> FileRegistrationResult:
+        """Register a document file with the external knowledge service.
+
+        This method registers a document with the external knowledge service,
+        allowing that service to analyze and index the document content for
+        future queries.
+
+        Args:
+            document_id: ID of the document to register
+
+        Returns:
+            FileRegistrationResult containing registration details and the
+            service's internal file identifier
+
+        Implementation Notes:
+        - Must be idempotent: re-registering same document returns same result
+        - Should handle service unavailability gracefully
+        - Must return the service's internal file ID for future queries
+        - May involve uploading document content to external service
+        - Should handle various document formats and sizes
+
+        Workflow Context:
+        In Temporal workflows, this method is implemented as an activity
+        to ensure registration results are durably stored and consistent
+        across workflow replays.
+        """
+        ...
+
+    async def execute_query(
+        self,
+        query_text: str,
+        document_ids: Optional[List[str]] = None,
+    ) -> QueryResult:
+        """Execute a query against the external knowledge service.
+
+        This method executes a text query against the knowledge service,
+        optionally scoping the query to specific documents that have been
+        previously registered with the service.
+
+        Args:
+            query_text: The query to execute (natural language or structured)
+            document_ids: Optional list of document IDs to scope the query to.
+                         If None, query runs against all registered documents.
+
+        Returns:
+            QueryResult containing query results and execution metadata
+
+        Implementation Notes:
+        - Must be idempotent: same query returns consistent results
+        - Document IDs are translated to service's internal file identifiers
+        - Should handle service unavailability gracefully
+        - Query results should be structured as domain objects
+        - Should track execution time and metadata
+        - Must handle various query formats (natural language, structured,
+          etc.)
+        - Should validate that document_ids have been registered before
+          querying
+
+        Workflow Context:
+        In Temporal workflows, this method is implemented as an activity
+        to ensure query results are durably stored and can be replayed
+        consistently.
+        """
+        ...


### PR DESCRIPTION
This PR is all architecture layout without implementation (hence no tests).

It adds:
- a `KnowledgeServiceConfig` domain model and repository for persistence, and
- a `KnowledgeService` protocol in a new `services` module, together with a stubbed anthropic implementation, with
- a factory function to return a specific KnowledgeService implementation when given a config.

Next up: I'll add implementations:
- `KnowledgeServiceConfig` needs minio and memory for consistency,
- `KnowledgeService` - I'll add a memory implementation for tests, then implement the anthropic implementation.