### PR TITLE
Add KnowledgeServiceConfig memory and minio implementations.

### DIFF
--- a/fun-police/systemPatterns.org
+++ b/fun-police/systemPatterns.org
@@ -3,6 +3,19 @@
 
 * Architectural Enforcement Patterns
 
+** REQUIRED READING
+
+*THIS DOCUMENT IS INCOMPLETE WITHOUT ITS COMPANION*
+
+Before proceeding, you MUST also read:
+- =fun-police/formatting.org= - Code formatting standards and line length rules
+
+These two documents work together as a unified system.
+The architectural patterns in this document assume compliance
+with the formatting standards defined in the companion document.
+
+*Both documents must be read and understood together.*
+
 ** Framework Philosophy
 
 This document defines the mandatory architectural patterns
@@ -17,8 +30,10 @@ By eliminating architectural decision-making during implementation,
 developers can focus their creative energy on solving business problems
 rather than debating patterns.
 
-*Note*: Code formatting standards (line length, style rules) are defined
-separately in =fun-police/formatting.org= and enforced via =pyproject.toml=.
+*CRITICAL NOTE*: This document defines architectural patterns only.
+Code formatting standards (78-character line limits, style rules) are defined
+in the companion document =fun-police/formatting.org= and enforced via =pyproject.toml=.
+Both documents are mandatory and work together as a unified system.
 
 ** Architecture Overview
 
@@ -32,7 +47,7 @@ innovation on architecture is explicitly prohibited
 to prevent technical debt and maintain system coherence.
 
 *Related Documentation*:
-- Code formatting standards: =fun-police/formatting.org=
+- Code formatting standards: =fun-police/formatting.org= *[REQUIRED - READ FIRST]*
 - Tooling configuration: =pyproject.toml=
 
 ** Core Architectural Patterns

--- a/julee_example/repositories/memory/__init__.py
+++ b/julee_example/repositories/memory/__init__.py
@@ -13,9 +13,11 @@ counterparts while providing lightweight, dependency-free alternatives.
 from .assembly import MemoryAssemblyRepository
 from .assembly_specification import MemoryAssemblySpecificationRepository
 from .document import MemoryDocumentRepository
+from .knowledge_service_config import MemoryKnowledgeServiceConfigRepository
 
 __all__ = [
     "MemoryAssemblyRepository",
     "MemoryAssemblySpecificationRepository",
     "MemoryDocumentRepository",
+    "MemoryKnowledgeServiceConfigRepository",
 ]

--- a/julee_example/repositories/memory/knowledge_service_config.py
+++ b/julee_example/repositories/memory/knowledge_service_config.py
@@ -1,0 +1,122 @@
+"""
+Memory implementation of KnowledgeServiceConfigRepository.
+
+This module provides an in-memory implementation of the KnowledgeServiceConfigRepository
+protocol that follows the Clean Architecture patterns defined in the
+Fun-Police Framework. It handles knowledge service configuration storage
+in memory dictionaries, ensuring idempotency and proper error handling.
+
+The implementation uses Python dictionaries to store knowledge service
+configuration data, making it ideal for testing scenarios where external
+dependencies should be avoided. All operations are still async to maintain
+interface compatibility.
+"""
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Optional, Dict
+
+from julee_example.domain import KnowledgeServiceConfig
+from julee_example.repositories.knowledge_service_config import KnowledgeServiceConfigRepository
+
+logger = logging.getLogger(__name__)
+
+
+class MemoryKnowledgeServiceConfigRepository(KnowledgeServiceConfigRepository):
+    """
+    Memory implementation of KnowledgeServiceConfigRepository using Python dictionaries.
+
+    This implementation stores knowledge service configurations in memory:
+    - Knowledge Services: Dictionary keyed by knowledge_service_id containing KnowledgeServiceConfig objects
+
+    This provides a lightweight, dependency-free option for testing while
+    maintaining the same interface as other implementations.
+    """
+
+    def __init__(self) -> None:
+        """Initialize repository with empty in-memory storage."""
+        logger.debug("Initializing MemoryKnowledgeServiceConfigRepository")
+
+        # Storage dictionary
+        self._knowledge_services: Dict[str, KnowledgeServiceConfig] = {}
+
+    async def get(
+        self, knowledge_service_id: str
+    ) -> Optional[KnowledgeServiceConfig]:
+        """Retrieve a knowledge service configuration by ID.
+
+        Args:
+            knowledge_service_id: Unique knowledge service identifier
+
+        Returns:
+            KnowledgeServiceConfig object if found, None otherwise
+        """
+        logger.debug(
+            "MemoryKnowledgeServiceConfigRepository: Attempting to retrieve knowledge service",
+            extra={"knowledge_service_id": knowledge_service_id},
+        )
+
+        knowledge_service = self._knowledge_services.get(knowledge_service_id)
+        if knowledge_service is None:
+            logger.debug(
+                "MemoryKnowledgeServiceConfigRepository: Knowledge service not found",
+                extra={"knowledge_service_id": knowledge_service_id},
+            )
+            return None
+
+        logger.info(
+            "MemoryKnowledgeServiceConfigRepository: Knowledge service retrieved successfully",
+            extra={
+                "knowledge_service_id": knowledge_service_id,
+                "name": knowledge_service.name,
+                "service_api": knowledge_service.service_api.value,
+            },
+        )
+
+        return knowledge_service
+
+    async def save(self, knowledge_service: KnowledgeServiceConfig) -> None:
+        """Save a knowledge service configuration.
+
+        Args:
+            knowledge_service: Complete KnowledgeServiceConfig to save
+        """
+        logger.debug(
+            "MemoryKnowledgeServiceConfigRepository: Saving knowledge service",
+            extra={"knowledge_service_id": knowledge_service.knowledge_service_id},
+        )
+
+        # Update timestamp
+        knowledge_service.updated_at = datetime.now(timezone.utc)
+
+        # Ensure created_at is set for new services
+        if knowledge_service.created_at is None:
+            knowledge_service.created_at = datetime.now(timezone.utc)
+
+        # Store the knowledge service (idempotent - will overwrite if exists)
+        self._knowledge_services[knowledge_service.knowledge_service_id] = knowledge_service
+
+        logger.info(
+            "MemoryKnowledgeServiceConfigRepository: Knowledge service saved successfully",
+            extra={
+                "knowledge_service_id": knowledge_service.knowledge_service_id,
+                "name": knowledge_service.name,
+                "service_api": knowledge_service.service_api.value,
+            },
+        )
+
+    async def generate_id(self) -> str:
+        """Generate a unique knowledge service identifier.
+
+        Returns:
+            Unique knowledge service ID string
+        """
+        knowledge_service_id = f"ks-{uuid.uuid4()}"
+
+        logger.debug(
+            "MemoryKnowledgeServiceConfigRepository: Generated knowledge service ID",
+            extra={"knowledge_service_id": knowledge_service_id},
+        )
+
+        return knowledge_service_id

--- a/julee_example/repositories/memory/knowledge_service_config.py
+++ b/julee_example/repositories/memory/knowledge_service_config.py
@@ -1,7 +1,8 @@
 """
 Memory implementation of KnowledgeServiceConfigRepository.
 
-This module provides an in-memory implementation of the KnowledgeServiceConfigRepository
+This module provides an in-memory implementation of the
+KnowledgeServiceConfigRepository
 protocol that follows the Clean Architecture patterns defined in the
 Fun-Police Framework. It handles knowledge service configuration storage
 in memory dictionaries, ensuring idempotency and proper error handling.
@@ -18,17 +19,23 @@ from datetime import datetime, timezone
 from typing import Optional, Dict
 
 from julee_example.domain import KnowledgeServiceConfig
-from julee_example.repositories.knowledge_service_config import KnowledgeServiceConfigRepository
+from julee_example.repositories.knowledge_service_config import (
+    KnowledgeServiceConfigRepository,
+)
 
 logger = logging.getLogger(__name__)
 
 
-class MemoryKnowledgeServiceConfigRepository(KnowledgeServiceConfigRepository):
+class MemoryKnowledgeServiceConfigRepository(
+    KnowledgeServiceConfigRepository
+):
     """
-    Memory implementation of KnowledgeServiceConfigRepository using Python dictionaries.
+    Memory implementation of KnowledgeServiceConfigRepository using Python
+    dictionaries.
 
     This implementation stores knowledge service configurations in memory:
-    - Knowledge Services: Dictionary keyed by knowledge_service_id containing KnowledgeServiceConfig objects
+    - Knowledge Services: Dictionary keyed by knowledge_service_id containing
+      KnowledgeServiceConfig objects
 
     This provides a lightweight, dependency-free option for testing while
     maintaining the same interface as other implementations.
@@ -53,23 +60,26 @@ class MemoryKnowledgeServiceConfigRepository(KnowledgeServiceConfigRepository):
             KnowledgeServiceConfig object if found, None otherwise
         """
         logger.debug(
-            "MemoryKnowledgeServiceConfigRepository: Attempting to retrieve knowledge service",
+            "MemoryKnowledgeServiceConfigRepository: Attempting to retrieve "
+            "knowledge service",
             extra={"knowledge_service_id": knowledge_service_id},
         )
 
         knowledge_service = self._knowledge_services.get(knowledge_service_id)
         if knowledge_service is None:
             logger.debug(
-                "MemoryKnowledgeServiceConfigRepository: Knowledge service not found",
+                "MemoryKnowledgeServiceConfigRepository: Knowledge service "
+                "not found",
                 extra={"knowledge_service_id": knowledge_service_id},
             )
             return None
 
         logger.info(
-            "MemoryKnowledgeServiceConfigRepository: Knowledge service retrieved successfully",
+            "MemoryKnowledgeServiceConfigRepository: Knowledge service "
+            "retrieved successfully",
             extra={
                 "knowledge_service_id": knowledge_service_id,
-                "name": knowledge_service.name,
+                "service_name": knowledge_service.name,
                 "service_api": knowledge_service.service_api.value,
             },
         )
@@ -83,8 +93,13 @@ class MemoryKnowledgeServiceConfigRepository(KnowledgeServiceConfigRepository):
             knowledge_service: Complete KnowledgeServiceConfig to save
         """
         logger.debug(
-            "MemoryKnowledgeServiceConfigRepository: Saving knowledge service",
-            extra={"knowledge_service_id": knowledge_service.knowledge_service_id},
+            "MemoryKnowledgeServiceConfigRepository: Saving knowledge "
+            "service",
+            extra={
+                "knowledge_service_id": (
+                    knowledge_service.knowledge_service_id
+                )
+            },
         )
 
         # Update timestamp
@@ -95,13 +110,18 @@ class MemoryKnowledgeServiceConfigRepository(KnowledgeServiceConfigRepository):
             knowledge_service.created_at = datetime.now(timezone.utc)
 
         # Store the knowledge service (idempotent - will overwrite if exists)
-        self._knowledge_services[knowledge_service.knowledge_service_id] = knowledge_service
+        self._knowledge_services[knowledge_service.knowledge_service_id] = (
+            knowledge_service
+        )
 
         logger.info(
-            "MemoryKnowledgeServiceConfigRepository: Knowledge service saved successfully",
+            "MemoryKnowledgeServiceConfigRepository: Knowledge service "
+            "saved successfully",
             extra={
-                "knowledge_service_id": knowledge_service.knowledge_service_id,
-                "name": knowledge_service.name,
+                "knowledge_service_id": (
+                    knowledge_service.knowledge_service_id
+                ),
+                "service_name": knowledge_service.name,
                 "service_api": knowledge_service.service_api.value,
             },
         )
@@ -115,7 +135,8 @@ class MemoryKnowledgeServiceConfigRepository(KnowledgeServiceConfigRepository):
         knowledge_service_id = f"ks-{uuid.uuid4()}"
 
         logger.debug(
-            "MemoryKnowledgeServiceConfigRepository: Generated knowledge service ID",
+            "MemoryKnowledgeServiceConfigRepository: Generated knowledge "
+            "service ID",
             extra={"knowledge_service_id": knowledge_service_id},
         )
 

--- a/julee_example/repositories/minio/__init__.py
+++ b/julee_example/repositories/minio/__init__.py
@@ -1,0 +1,23 @@
+"""
+Minio repository implementations for julee_example domain.
+
+This module exports Minio-based implementations of all repository protocols
+for the Capture, Extract, Assemble, Publish workflow. These implementations
+use Minio for object storage and are suitable for production environments
+where persistent, scalable storage is required.
+
+All implementations maintain the same async interfaces as their memory
+counterparts while providing durable, distributed storage capabilities.
+"""
+
+from .assembly import MinioAssemblyRepository
+from .assembly_specification import MinioAssemblySpecificationRepository
+from .document import MinioDocumentRepository
+from .knowledge_service_config import MinioKnowledgeServiceConfigRepository
+
+__all__ = [
+    "MinioAssemblyRepository",
+    "MinioAssemblySpecificationRepository",
+    "MinioDocumentRepository",
+    "MinioKnowledgeServiceConfigRepository",
+]

--- a/julee_example/repositories/minio/assembly.py
+++ b/julee_example/repositories/minio/assembly.py
@@ -46,7 +46,9 @@ class MinioAssemblyRepository(AssemblyRepository, MinioRepositoryMixin):
         self.logger = logging.getLogger("MinioAssemblyRepository")
         self.assembly_bucket = "assemblies"
         self.iterations_bucket = "assembly-iterations"
-        self.ensure_buckets_exist([self.assembly_bucket, self.iterations_bucket])
+        self.ensure_buckets_exist(
+            [self.assembly_bucket, self.iterations_bucket]
+        )
 
     async def get(self, assembly_id: str) -> Optional[Assembly]:
         """Retrieve an assembly with all its iterations."""
@@ -57,7 +59,7 @@ class MinioAssemblyRepository(AssemblyRepository, MinioRepositoryMixin):
             model_class=Assembly,
             not_found_log_message="Assembly not found",
             error_log_message="Error retrieving assembly",
-            extra_log_data={"assembly_id": assembly_id}
+            extra_log_data={"assembly_id": assembly_id},
         )
 
         if assembly is None:
@@ -135,7 +137,7 @@ class MinioAssemblyRepository(AssemblyRepository, MinioRepositoryMixin):
                 "assembly_id": assembly_id,
                 "iteration_id": new_iteration.iteration_id,
                 "document_id": document_id,
-            }
+            },
         )
 
         # Update assembly's updated_at timestamp and save
@@ -169,7 +171,7 @@ class MinioAssemblyRepository(AssemblyRepository, MinioRepositoryMixin):
             extra_log_data={
                 "assembly_id": assembly.assembly_id,
                 "status": assembly.status.value,
-            }
+            },
         )
 
     async def generate_id(self) -> str:

--- a/julee_example/repositories/minio/assembly_specification.py
+++ b/julee_example/repositories/minio/assembly_specification.py
@@ -23,7 +23,9 @@ from julee_example.repositories.assembly_specification import (
 from .client import MinioClient, MinioRepositoryMixin
 
 
-class MinioAssemblySpecificationRepository(AssemblySpecificationRepository, MinioRepositoryMixin):
+class MinioAssemblySpecificationRepository(
+    AssemblySpecificationRepository, MinioRepositoryMixin
+):
     """
     Minio implementation of AssemblySpecificationRepository using Minio for
     persistence.
@@ -40,7 +42,9 @@ class MinioAssemblySpecificationRepository(AssemblySpecificationRepository, Mini
             client: MinioClient protocol implementation (real or fake)
         """
         self.client = client
-        self.logger = logging.getLogger("MinioAssemblySpecificationRepository")
+        self.logger = logging.getLogger(
+            "MinioAssemblySpecificationRepository"
+        )
         self.specifications_bucket = "assembly-specifications"
         self.ensure_buckets_exist(self.specifications_bucket)
 
@@ -54,7 +58,9 @@ class MinioAssemblySpecificationRepository(AssemblySpecificationRepository, Mini
             model_class=AssemblySpecification,
             not_found_log_message="Specification not found",
             error_log_message="Error retrieving specification",
-            extra_log_data={"assembly_specification_id": assembly_specification_id}
+            extra_log_data={
+                "assembly_specification_id": assembly_specification_id
+            },
         )
 
     async def save(
@@ -71,11 +77,13 @@ class MinioAssemblySpecificationRepository(AssemblySpecificationRepository, Mini
             success_log_message="Specification saved successfully",
             error_log_message="Error saving specification",
             extra_log_data={
-                "assembly_specification_id": assembly_specification.assembly_specification_id,
+                "assembly_specification_id": (
+                    assembly_specification.assembly_specification_id
+                ),
                 "spec_name": assembly_specification.name,
                 "status": assembly_specification.status.value,
                 "version": assembly_specification.version,
-            }
+            },
         )
 
     async def generate_id(self) -> str:

--- a/julee_example/repositories/minio/assembly_specification.py
+++ b/julee_example/repositories/minio/assembly_specification.py
@@ -13,21 +13,13 @@ guidelines. Each specification is stored as a complete JSON document with its
 schema and query mappings.
 """
 
-import json
-import logging
-import uuid
-from datetime import datetime, timezone
 from typing import Optional
-
-from minio.error import S3Error  # type: ignore[import-untyped]
 
 from julee_example.domain import AssemblySpecification
 from julee_example.repositories.assembly_specification import (
     AssemblySpecificationRepository,
 )
-from .client import MinioClient
-
-logger = logging.getLogger(__name__)
+from .client import MinioClient, MinioRepositoryClient
 
 
 class MinioAssemblySpecificationRepository(AssemblySpecificationRepository):
@@ -46,165 +38,44 @@ class MinioAssemblySpecificationRepository(AssemblySpecificationRepository):
         Args:
             client: MinioClient protocol implementation (real or fake)
         """
-        logger.debug("Initializing MinioAssemblySpecificationRepository")
-
-        self.client = client
+        self.repo_client = MinioRepositoryClient(client, "MinioAssemblySpecificationRepository")
         self.specifications_bucket = "assembly-specifications"
-        self._ensure_bucket_exists()
-
-    def _ensure_bucket_exists(self) -> None:
-        """Ensure specifications bucket exists."""
-        try:
-            if not self.client.bucket_exists(self.specifications_bucket):
-                logger.info(
-                    "Creating assembly specifications bucket",
-                    extra={"bucket_name": self.specifications_bucket},
-                )
-                self.client.make_bucket(self.specifications_bucket)
-            else:
-                logger.debug(
-                    "Assembly specifications bucket already exists",
-                    extra={"bucket_name": self.specifications_bucket},
-                )
-        except S3Error as e:
-            logger.error(
-                "Failed to create assembly specifications bucket",
-                extra={
-                    "bucket_name": self.specifications_bucket,
-                    "error": str(e),
-                },
-            )
-            raise
+        self.repo_client.ensure_buckets_exist(self.specifications_bucket)
 
     async def get(
         self, assembly_specification_id: str
     ) -> Optional[AssemblySpecification]:
         """Retrieve an assembly specification by ID."""
-        logger.debug(
-            "MinioAssemblySpecificationRepository: Attempting to retrieve "
-            "specification",
-            extra={
-                "assembly_specification_id": assembly_specification_id,
-                "bucket": self.specifications_bucket,
-            },
+        return self.repo_client.get_json_object(
+            bucket_name=self.specifications_bucket,
+            object_name=assembly_specification_id,
+            model_class=AssemblySpecification,
+            not_found_log_message="Specification not found",
+            error_log_message="Error retrieving specification",
+            extra_log_data={"assembly_specification_id": assembly_specification_id}
         )
-
-        try:
-            response = self.client.get_object(
-                bucket_name=self.specifications_bucket,
-                object_name=assembly_specification_id,
-            )
-            data = response.read()
-            response.close()
-            response.release_conn()
-
-            specification_json = data.decode("utf-8")
-            specification_dict = json.loads(specification_json)
-
-            logger.info(
-                "MinioAssemblySpecificationRepository: Specification "
-                "retrieved successfully",
-                extra={
-                    "assembly_specification_id": assembly_specification_id,
-                    "spec_name": specification_dict.get("name"),
-                    "status": specification_dict.get("status"),
-                    "version": specification_dict.get("version"),
-                    "retrieved_at": datetime.now(timezone.utc).isoformat(),
-                },
-            )
-
-            return AssemblySpecification(**specification_dict)
-
-        except S3Error as e:
-            if getattr(e, "code", None) == "NoSuchKey":
-                logger.debug(
-                    "MinioAssemblySpecificationRepository: Specification not "
-                    "found",
-                    extra={
-                        "assembly_specification_id": assembly_specification_id
-                    },
-                )
-                return None
-            else:
-                logger.error(
-                    "MinioAssemblySpecificationRepository: Error retrieving "
-                    "specification",
-                    extra={
-                        "assembly_specification_id": (
-                            assembly_specification_id
-                        ),
-                        "error": str(e),
-                    },
-                )
-                raise
 
     async def save(
         self, assembly_specification: AssemblySpecification
     ) -> None:
-        """Save an assembly specification."""
-        logger.debug(
-            "MinioAssemblySpecificationRepository: Saving specification",
-            extra={
-                "assembly_specification_id": (
-                    assembly_specification.assembly_specification_id
-                ),
+        """Save an assembly specification to Minio."""
+        # Update timestamps
+        self.repo_client.update_timestamps(assembly_specification)
+
+        self.repo_client.put_json_object(
+            bucket_name=self.specifications_bucket,
+            object_name=assembly_specification.assembly_specification_id,
+            model=assembly_specification,
+            success_log_message="Specification saved successfully",
+            error_log_message="Error saving specification",
+            extra_log_data={
+                "assembly_specification_id": assembly_specification.assembly_specification_id,
                 "spec_name": assembly_specification.name,
                 "status": assembly_specification.status.value,
-            },
+                "version": assembly_specification.version,
+            }
         )
-
-        try:
-            # Update timestamp
-            assembly_specification.updated_at = datetime.now(timezone.utc)
-
-            # Use Pydantic's JSON serialization for proper datetime handling
-            specification_json = assembly_specification.model_dump_json()
-
-            self.client.put_object(
-                bucket_name=self.specifications_bucket,
-                object_name=assembly_specification.assembly_specification_id,
-                data=specification_json.encode("utf-8"),
-                length=len(specification_json.encode("utf-8")),
-                content_type="application/json",
-            )
-
-            logger.info(
-                "MinioAssemblySpecificationRepository: Specification saved "
-                "successfully",
-                extra={
-                    "assembly_specification_id": (
-                        assembly_specification.assembly_specification_id
-                    ),
-                    "spec_name": assembly_specification.name,
-                    "status": assembly_specification.status.value,
-                    "version": assembly_specification.version,
-                    "updated_at": (
-                        assembly_specification.updated_at.isoformat()
-                    ),
-                },
-            )
-
-        except S3Error as e:
-            logger.error(
-                "MinioAssemblySpecificationRepository: Error saving "
-                "specification",
-                extra={
-                    "assembly_specification_id": (
-                        assembly_specification.assembly_specification_id
-                    ),
-                    "error": str(e),
-                },
-            )
-            raise
 
     async def generate_id(self) -> str:
         """Generate a unique assembly specification identifier."""
-        specification_id = str(uuid.uuid4())
-
-        logger.debug(
-            "MinioAssemblySpecificationRepository: Generated specification "
-            "ID",
-            extra={"assembly_specification_id": specification_id},
-        )
-
-        return specification_id
+        return self.repo_client.generate_id_with_prefix("spec")

--- a/julee_example/repositories/minio/client.py
+++ b/julee_example/repositories/minio/client.py
@@ -6,20 +6,29 @@ and our fake test client must implement. This follows Clean Architecture
 dependency inversion principles by depending on abstractions rather than
 concrete implementations.
 
-It also provides MinioRepositoryClient, a composition wrapper that encapsulates
+It also provides MinioRepositoryMixin, a mixin that encapsulates
 common patterns used across all Minio repository implementations to reduce
 code duplication and ensure consistent error handling and logging.
 """
 
 import json
 from datetime import datetime, timezone
-from typing import Protocol, Any, Dict, Optional, runtime_checkable, List, Union, TypeVar
+from typing import (
+    Protocol,
+    Any,
+    Dict,
+    Optional,
+    runtime_checkable,
+    List,
+    Union,
+    TypeVar,
+)
 from urllib3.response import HTTPResponse
 from minio.datatypes import Object
 from minio.error import S3Error  # type: ignore[import-untyped]
 from pydantic import BaseModel
 
-T = TypeVar('T', bound=BaseModel)
+T = TypeVar("T", bound=BaseModel)
 
 
 @runtime_checkable
@@ -131,7 +140,8 @@ class MinioRepositoryMixin:
     """
     Mixin that provides common repository patterns for Minio implementations.
 
-    This mixin encapsulates common functionality used across all Minio repository
+    This mixin encapsulates common functionality used across all Minio
+    repository
     implementations, including:
     - Bucket creation and management
     - JSON serialization/deserialization with proper error handling
@@ -149,7 +159,9 @@ class MinioRepositoryMixin:
     client: MinioClient
     logger: Any  # logging.Logger, but avoiding import
 
-    def ensure_buckets_exist(self, bucket_names: Union[str, List[str]]) -> None:
+    def ensure_buckets_exist(
+        self, bucket_names: Union[str, List[str]]
+    ) -> None:
         """Ensure one or more buckets exist, creating them if necessary.
 
         Args:
@@ -188,9 +200,10 @@ class MinioRepositoryMixin:
         model_class: type[T],
         not_found_log_message: str,
         error_log_message: str,
-        extra_log_data: Optional[Dict[str, Any]] = None
+        extra_log_data: Optional[Dict[str, Any]] = None,
     ) -> Optional[T]:
-        """Get a JSON object from Minio and deserialize it to a Pydantic model.
+        """Get a JSON object from Minio and deserialize it to a Pydantic
+        model.
 
         Args:
             bucket_name: Name of the bucket
@@ -210,8 +223,7 @@ class MinioRepositoryMixin:
 
         try:
             response = self.client.get_object(
-                bucket_name=bucket_name,
-                object_name=object_name
+                bucket_name=bucket_name, object_name=object_name
             )
 
             # Read and clean up response
@@ -246,7 +258,7 @@ class MinioRepositoryMixin:
         model: BaseModel,
         success_log_message: str,
         error_log_message: str,
-        extra_log_data: Optional[Dict[str, Any]] = None
+        extra_log_data: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Store a Pydantic model as a JSON object in Minio.
 
@@ -288,7 +300,8 @@ class MinioRepositoryMixin:
             raise
 
     def update_timestamps(self, model: Any) -> None:
-        """Update timestamps on a model (created_at if None, always updated_at).
+        """Update timestamps on a model (created_at if None, always
+        updated_at).
 
         Args:
             model: Pydantic model with created_at and updated_at fields
@@ -296,12 +309,15 @@ class MinioRepositoryMixin:
         now = datetime.now(timezone.utc)
 
         # Set created_at if it's None (for new objects)
-        if hasattr(model, 'created_at') and getattr(model, 'created_at', None) is None:
-            setattr(model, 'created_at', now)
+        if (
+            hasattr(model, "created_at")
+            and getattr(model, "created_at", None) is None
+        ):
+            setattr(model, "created_at", now)
 
         # Always update updated_at
-        if hasattr(model, 'updated_at'):
-            setattr(model, 'updated_at', now)
+        if hasattr(model, "updated_at"):
+            setattr(model, "updated_at", now)
 
     def generate_id_with_prefix(self, prefix: str) -> str:
         """Generate a unique ID with the given prefix and log the generation.

--- a/julee_example/repositories/minio/client.py
+++ b/julee_example/repositories/minio/client.py
@@ -12,7 +12,6 @@ code duplication and ensure consistent error handling and logging.
 """
 
 import json
-import logging
 from datetime import datetime, timezone
 from typing import Protocol, Any, Dict, Optional, runtime_checkable, List, Union, TypeVar
 from urllib3.response import HTTPResponse
@@ -128,31 +127,27 @@ class MinioClient(Protocol):
         ...
 
 
-class MinioRepositoryClient:
+class MinioRepositoryMixin:
     """
-    Composition wrapper for MinioClient that provides common repository patterns.
+    Mixin that provides common repository patterns for Minio implementations.
 
-    This class encapsulates common functionality used across all Minio repository
+    This mixin encapsulates common functionality used across all Minio repository
     implementations, including:
     - Bucket creation and management
     - JSON serialization/deserialization with proper error handling
     - Standardized S3Error handling for NoSuchKey cases
     - Consistent logging patterns
     - Response cleanup
+    - ID generation with logging
 
-    By using composition, repositories can delegate common operations to this
-    client while maintaining clean, focused domain logic.
+    Classes using this mixin must provide:
+    - self.client: MinioClient instance
+    - self.logger: logging.Logger instance (typically set in __init__)
     """
 
-    def __init__(self, client: MinioClient, logger_name: str) -> None:
-        """Initialize the repository client.
-
-        Args:
-            client: MinioClient protocol implementation (real or fake)
-            logger_name: Name for the logger (e.g., 'MinioAssemblyRepository')
-        """
-        self.client = client
-        self.logger = logging.getLogger(logger_name)
+    # Type annotations for attributes that implementing classes must provide
+    client: MinioClient
+    logger: Any  # logging.Logger, but avoiding import
 
     def ensure_buckets_exist(self, bucket_names: Union[str, List[str]]) -> None:
         """Ensure one or more buckets exist, creating them if necessary.

--- a/julee_example/repositories/minio/document.py
+++ b/julee_example/repositories/minio/document.py
@@ -50,8 +50,6 @@ class MinioDocumentRepository(DocumentRepository, MinioRepositoryMixin):
         self.content_bucket = "documents-content"
         self.ensure_buckets_exist([self.metadata_bucket, self.content_bucket])
 
-
-
     async def get(self, document_id: str) -> Optional[Document]:
         """Retrieve a document with metadata and content."""
         try:
@@ -93,7 +91,9 @@ class MinioDocumentRepository(DocumentRepository, MinioRepositoryMixin):
                     extra={
                         "document_id": document_id,
                         "content_multihash": content_multihash,
-                        "retrieved_at": datetime.now(timezone.utc).isoformat(),
+                        "retrieved_at": datetime.now(
+                            timezone.utc
+                        ).isoformat(),
                     },
                 )
 
@@ -108,7 +108,8 @@ class MinioDocumentRepository(DocumentRepository, MinioRepositoryMixin):
                             "content_multihash": content_multihash,
                         },
                     )
-                    # Return document without content stream for metadata-only operations
+                    # Return document without content stream for metadata-only
+                    # operations
                     document_dict["content"] = ContentStream(io.BytesIO(b""))
                     return Document(**document_dict)
                 else:
@@ -158,7 +159,8 @@ class MinioDocumentRepository(DocumentRepository, MinioRepositoryMixin):
             # Verify and update multihash if needed
             if document.content_multihash != calculated_multihash:
                 self.logger.warning(
-                    "Provided multihash differs from calculated, using calculated",
+                    "Provided multihash differs from calculated, using "
+                    "calculated",
                     extra={
                         "document_id": document.document_id,
                         "provided_multihash": document.content_multihash,
@@ -246,9 +248,12 @@ class MinioDocumentRepository(DocumentRepository, MinioRepositoryMixin):
         return self.generate_id_with_prefix("doc")
 
     async def _store_content(self, document: Document) -> str:
-        """Store document content to content-addressable storage and return multihash."""
+        """Store document content to content-addressable storage and return
+        multihash."""
         if not document.content:
-            raise ValueError(f"Document {document.document_id} has no content")
+            raise ValueError(
+                f"Document {document.document_id} has no content"
+            )
 
         # Calculate multihash from the content stream
         calculated_multihash = self._calculate_multihash_from_stream(
@@ -286,7 +291,8 @@ class MinioDocumentRepository(DocumentRepository, MinioRepositoryMixin):
                 object_name=object_name,
                 data=io.BytesIO(content_data),
                 length=len(content_data),
-                content_type=document.content_type or "application/octet-stream",
+                content_type=document.content_type
+                or "application/octet-stream",
                 metadata={
                     "document_id": document.document_id,
                     "original_filename": document.original_filename or "",
@@ -314,7 +320,9 @@ class MinioDocumentRepository(DocumentRepository, MinioRepositoryMixin):
             )
             raise
 
-    def _calculate_multihash_from_stream(self, content_stream: ContentStream) -> str:
+    def _calculate_multihash_from_stream(
+        self, content_stream: ContentStream
+    ) -> str:
         """Calculate multihash from content stream."""
         if not content_stream:
             raise ValueError("Content stream is required")

--- a/julee_example/repositories/minio/document.py
+++ b/julee_example/repositories/minio/document.py
@@ -12,9 +12,6 @@ payload handling pattern from the architectural guidelines."""
 
 import io
 import json
-
-import logging
-import uuid
 import hashlib
 from datetime import datetime, timezone
 from typing import Optional
@@ -24,9 +21,7 @@ import multihash  # type: ignore[import-untyped]
 
 from julee_example.domain import Document, ContentStream
 from julee_example.repositories.document import DocumentRepository
-from .client import MinioClient
-
-logger = logging.getLogger(__name__)
+from .client import MinioClient, MinioRepositoryClient
 
 
 class MinioDocumentRepository(DocumentRepository):
@@ -47,49 +42,34 @@ class MinioDocumentRepository(DocumentRepository):
         Args:
             client: MinioClient protocol implementation (real or fake)
         """
-        logger.debug("Initializing MinioDocumentRepository")
-
-        self.client = client
+        self.repo_client = MinioRepositoryClient(client, "MinioDocumentRepository")
         self.metadata_bucket = "documents"
         self.content_bucket = "documents-content"
-        self._ensure_buckets_exist()
+        self.repo_client.ensure_buckets_exist([self.metadata_bucket, self.content_bucket])
 
-    def _ensure_buckets_exist(self) -> None:
-        """Ensure both metadata and content buckets exist."""
-        for bucket_name in [self.metadata_bucket, self.content_bucket]:
-            try:
-                if not self.client.bucket_exists(bucket_name):
-                    logger.info(
-                        "Creating document bucket",
-                        extra={"bucket_name": bucket_name},
-                    )
-                    self.client.make_bucket(bucket_name)
-                else:
-                    logger.debug(
-                        "Document bucket already exists",
-                        extra={"bucket_name": bucket_name},
-                    )
-            except S3Error as e:
-                logger.error(
-                    "Failed to create document bucket",
-                    extra={"bucket_name": bucket_name, "error": str(e)},
-                )
-                raise
+    @property
+    def client(self) -> MinioClient:
+        """Provide backward compatibility access to the underlying Minio client."""
+        if hasattr(self, 'repo_client'):
+            return self.repo_client.client
+        else:
+            # For test cases that use __new__ without __init__
+            return getattr(self, '_client')
+
+    @client.setter
+    def client(self, value: MinioClient) -> None:
+        """Allow setting the client for test compatibility."""
+        if hasattr(self, 'repo_client'):
+            self.repo_client.client = value
+        else:
+            # For test cases that use __new__ without __init__
+            self._client = value
 
     async def get(self, document_id: str) -> Optional[Document]:
         """Retrieve a document with metadata and content."""
-        logger.debug(
-            "MinioDocumentRepository: Attempting to retrieve document",
-            extra={
-                "document_id": document_id,
-                "metadata_bucket": self.metadata_bucket,
-                "content_bucket": self.content_bucket,
-            },
-        )
-
         try:
             # First, get the metadata
-            metadata_response = self.client.get_object(
+            metadata_response = self.repo_client.client.get_object(
                 bucket_name=self.metadata_bucket, object_name=document_id
             )
             metadata_data = metadata_response.read()
@@ -104,15 +84,14 @@ class MinioDocumentRepository(DocumentRepository):
             # Now get the content stream using the content multihash as key
             content_multihash = document_dict.get("content_multihash")
             if not content_multihash:
-                logger.error(
-                    "MinioDocumentRepository: Document metadata missing "
-                    "content_multihash",
+                self.repo_client.logger.error(
+                    "Document metadata missing content_multihash",
                     extra={"document_id": document_id},
                 )
                 return None
 
             try:
-                content_response = self.client.get_object(
+                content_response = self.repo_client.client.get_object(
                     bucket_name=self.content_bucket,
                     object_name=content_multihash,
                 )
@@ -122,22 +101,12 @@ class MinioDocumentRepository(DocumentRepository):
                 content_stream = ContentStream(content_response)
                 document_dict["content"] = content_stream
 
-                logger.info(
-                    "MinioDocumentRepository: Document retrieved "
-                    "successfully",
+                self.repo_client.logger.info(
+                    "Document retrieved successfully",
                     extra={
                         "document_id": document_id,
                         "content_multihash": content_multihash,
-                        "original_filename": document_dict.get(
-                            "original_filename"
-                        ),
-                        "content_type": document_dict.get("content_type"),
-                        "size_bytes": document_dict.get("size_bytes"),
-                        "status": document_dict.get("status"),
-                        "retrieved_at": datetime.now(
-                            timezone.utc
-                        ).isoformat(),
-                        "metadata_size_bytes": len(metadata_data),
+                        "retrieved_at": datetime.now(timezone.utc).isoformat(),
                     },
                 )
 
@@ -145,17 +114,14 @@ class MinioDocumentRepository(DocumentRepository):
 
             except S3Error as content_error:
                 if getattr(content_error, "code", None) == "NoSuchKey":
-                    logger.warning(
-                        "MinioDocumentRepository: Document metadata found "
-                        "but content missing",
+                    self.repo_client.logger.warning(
+                        "Document metadata found but content missing",
                         extra={
                             "document_id": document_id,
                             "content_multihash": content_multihash,
-                            "error_code": "NoSuchKey",
                         },
                     )
-                    # Return document without content stream for metadata-only
-                    # operations
+                    # Return document without content stream for metadata-only operations
                     document_dict["content"] = ContentStream(io.BytesIO(b""))
                     return Document(**document_dict)
                 else:
@@ -163,35 +129,23 @@ class MinioDocumentRepository(DocumentRepository):
 
         except S3Error as e:
             if getattr(e, "code", None) == "NoSuchKey":
-                logger.debug(
-                    "MinioDocumentRepository: Document not found in Minio "
-                    "storage (NoSuchKey)",
-                    extra={
-                        "document_id": document_id,
-                        "error_code": "NoSuchKey",
-                    },
+                self.repo_client.logger.debug(
+                    "Document not found",
+                    extra={"document_id": document_id},
                 )
                 return None
             else:
-                logger.error(
-                    "MinioDocumentRepository: Error retrieving document "
-                    "metadata from Minio",
-                    extra={
-                        "document_id": document_id,
-                        "error": str(e),
-                        "error_type": type(e).__name__,
-                    },
-                    exc_info=True,
+                self.repo_client.logger.error(
+                    "Error retrieving document metadata",
+                    extra={"document_id": document_id, "error": str(e)},
                 )
-                return None
+                raise
         except Exception as e:
-            logger.error(
-                "MinioDocumentRepository: Unexpected error during document "
-                "retrieval",
+            self.repo_client.logger.error(
+                "Unexpected error during document retrieval",
                 extra={
                     "document_id": document_id,
                     "error": str(e),
-                    "error_type": type(e).__name__,
                 },
                 exc_info=True,
             )
@@ -199,8 +153,8 @@ class MinioDocumentRepository(DocumentRepository):
 
     async def store(self, document: Document) -> None:
         """Store a new document with its content and metadata."""
-        logger.info(
-            "MinioDocumentRepository: Storing document",
+        self.repo_client.logger.info(
+            "Storing document",
             extra={
                 "document_id": document.document_id,
                 "original_filename": document.original_filename,
@@ -216,9 +170,8 @@ class MinioDocumentRepository(DocumentRepository):
 
             # Verify and update multihash if needed
             if document.content_multihash != calculated_multihash:
-                logger.warning(
-                    "MinioDocumentRepository: Provided multihash differs "
-                    "from calculated, using calculated",
+                self.repo_client.logger.warning(
+                    "Provided multihash differs from calculated, using calculated",
                     extra={
                         "document_id": document.document_id,
                         "provided_multihash": document.content_multihash,
@@ -230,23 +183,20 @@ class MinioDocumentRepository(DocumentRepository):
             # Store metadata second (atomic operation)
             await self._store_metadata(document)
 
-            logger.info(
-                "MinioDocumentRepository: Document stored successfully",
+            self.repo_client.logger.info(
+                "Document stored successfully",
                 extra={
                     "document_id": document.document_id,
                     "content_multihash": calculated_multihash,
-                    "metadata_bucket": self.metadata_bucket,
-                    "content_bucket": self.content_bucket,
                 },
             )
 
         except Exception as e:
-            logger.error(
-                "MinioDocumentRepository: Failed to store document",
+            self.repo_client.logger.error(
+                "Failed to store document",
                 extra={
                     "document_id": document.document_id,
                     "error": str(e),
-                    "error_type": type(e).__name__,
                 },
                 exc_info=True,
             )
@@ -254,8 +204,8 @@ class MinioDocumentRepository(DocumentRepository):
 
     async def update(self, document: Document) -> None:
         """Update a complete document with content and metadata."""
-        logger.info(
-            "MinioDocumentRepository: Updating document",
+        self.repo_client.logger.info(
+            "Updating document",
             extra={
                 "document_id": document.document_id,
                 "original_filename": document.original_filename,
@@ -263,49 +213,42 @@ class MinioDocumentRepository(DocumentRepository):
             },
         )
 
-        # Update the timestamp
-        document.updated_at = datetime.now(timezone.utc)
+        # Update timestamp
+        self.repo_client.update_timestamps(document)
 
         try:
-            # Store content using multihash key and get calculated multihash
+            # Store content and get calculated multihash
             calculated_multihash = await self._store_content(document)
 
-            # Verify and update multihash if needed
+            # Update multihash if needed
             if document.content_multihash != calculated_multihash:
-                logger.warning(
-                    "MinioDocumentRepository: Provided multihash differs "
-                    "from calculated, using calculated",
+                self.repo_client.logger.warning(
+                    "Content changed during update, updating multihash",
                     extra={
                         "document_id": document.document_id,
-                        "provided_multihash": document.content_multihash,
-                        "calculated_multihash": calculated_multihash,
+                        "old_multihash": document.content_multihash,
+                        "new_multihash": calculated_multihash,
                     },
                 )
                 document.content_multihash = calculated_multihash
 
-            # Always update metadata (includes updated_at timestamp)
+            # Store updated metadata
             await self._store_metadata(document)
 
-            logger.info(
-                "MinioDocumentRepository: Document updated successfully",
+            self.repo_client.logger.info(
+                "Document updated successfully",
                 extra={
                     "document_id": document.document_id,
                     "content_multihash": calculated_multihash,
-                    "updated_at": (
-                        document.updated_at.isoformat()
-                        if document.updated_at
-                        else None
-                    ),
                 },
             )
 
         except Exception as e:
-            logger.error(
-                "MinioDocumentRepository: Failed to update document",
+            self.repo_client.logger.error(
+                "Failed to update document",
                 extra={
                     "document_id": document.document_id,
                     "error": str(e),
-                    "error_type": type(e).__name__,
                 },
                 exc_info=True,
             )
@@ -313,150 +256,92 @@ class MinioDocumentRepository(DocumentRepository):
 
     async def generate_id(self) -> str:
         """Generate a unique document identifier."""
-        document_id = str(uuid.uuid4())
-
-        logger.debug(
-            "MinioDocumentRepository: Generated document ID",
-            extra={
-                "document_id": document_id,
-                "generated_at": datetime.now(timezone.utc).isoformat(),
-            },
-        )
-
-        return document_id
+        return self.repo_client.generate_id_with_prefix("doc")
 
     async def _store_content(self, document: Document) -> str:
-        """Store document content to Minio using content multihash as key.
+        """Store document content to content-addressable storage and return multihash."""
+        if not document.content:
+            raise ValueError(f"Document {document.document_id} has no content")
 
-        This provides natural deduplication and immutability - identical
-        content
-        is only stored once regardless of how many documents reference it.
-
-        Returns:
-            The calculated multihash of the stored content
-        """
-        # First, calculate the actual multihash from content stream
-        document.content.seek(0)
+        # Calculate multihash from the content stream
         calculated_multihash = self._calculate_multihash_from_stream(
-            document.content.stream
+            document.content
         )
-
-        # Use calculated multihash as the key (not provided multihash)
         object_name = calculated_multihash
 
         try:
-            # Check if content already exists (idempotency via
-            # content-addressing)
+            # Check if content already exists (deduplication)
             try:
-                # Just check if the object exists - no need to read and
-                # compare
-                self.client.stat_object(
+                self.repo_client.client.stat_object(
                     bucket_name=self.content_bucket, object_name=object_name
                 )
-
-                logger.debug(
-                    "MinioDocumentRepository: Content already exists "
-                    "(content deduplication)",
+                # Content already exists, no need to store again
+                self.repo_client.logger.debug(
+                    "Content already exists, skipping storage",
                     extra={
                         "document_id": document.document_id,
-                        "content_multihash": object_name,
+                        "content_multihash": calculated_multihash,
                     },
                 )
                 return calculated_multihash
 
             except S3Error as e:
                 if getattr(e, "code", None) == "NoSuchKey":
-                    logger.debug(
-                        "MinioDocumentRepository: Content not found, "
-                        "storing new",
-                        extra={
-                            "document_id": document.document_id,
-                            "content_multihash": object_name,
-                        },
-                    )
-                    # Continue to store the content
+                    # Content doesn't exist, continue to store it
+                    pass
                 else:
                     raise  # Re-raise if it's another S3 error
 
             # Store the content using calculated multihash
-            document.content.seek(0)  # Reset stream position
-            # Pass the stream directly to Minio - no need to read into memory
-            self.client.put_object(
+            content_data = document.content.read()
+            self.repo_client.client.put_object(
                 bucket_name=self.content_bucket,
                 object_name=object_name,
-                data=document.content.stream,
-                length=document.size_bytes,
-                content_type=document.content_type,
+                data=io.BytesIO(content_data),
+                length=len(content_data),
+                content_type=document.content_type or "application/octet-stream",
                 metadata={
-                    "content_multihash": calculated_multihash,
-                    "content_type": document.content_type,
-                    "stored_at": datetime.now(timezone.utc).isoformat(),
+                    "document_id": document.document_id,
+                    "original_filename": document.original_filename or "",
                 },
             )
 
-            logger.debug(
-                "MinioDocumentRepository: Content stored successfully",
+            self.repo_client.logger.debug(
+                "Content stored successfully",
                 extra={
                     "document_id": document.document_id,
                     "content_multihash": calculated_multihash,
-                    "bucket": self.content_bucket,
-                    "content_size": document.size_bytes,
+                    "content_size": len(content_data),
                 },
             )
 
             return calculated_multihash
 
-        except S3Error as e:
-            logger.error(
-                "MinioDocumentRepository: Failed to store content to Minio",
-                extra={
-                    "document_id": document.document_id,
-                    "error": str(e),
-                    "error_type": type(e).__name__,
-                },
-                exc_info=True,
-            )
-            raise
         except Exception as e:
-            logger.error(
-                "MinioDocumentRepository: Unexpected error during content "
-                "storage",
+            self.repo_client.logger.error(
+                "Failed to store content",
                 extra={
                     "document_id": document.document_id,
                     "error": str(e),
-                    "error_type": type(e).__name__,
                 },
-                exc_info=True,
             )
             raise
 
-    def _calculate_multihash_from_stream(
-        self, stream: io.IOBase, chunk_size: int = 8192
-    ) -> str:
-        """Calculate SHA-256 multihash from a stream without loading all
-        content into memory.
+    def _calculate_multihash_from_stream(self, content_stream: ContentStream) -> str:
+        """Calculate multihash from content stream."""
+        if not content_stream:
+            raise ValueError("Content stream is required")
 
-        Args:
-            stream: The content stream to hash
-            chunk_size: Size of chunks to read at a time
+        # Read content and calculate SHA-256 hash
+        content_data = content_stream.read()
+        sha256_hash = hashlib.sha256(content_data).digest()
 
-        Returns:
-            Hex-encoded multihash string
-        """
-        hasher = hashlib.sha256()
+        # Reset stream position for future reads
+        content_stream.seek(0)
 
-        # Process stream in chunks
-        while True:
-            chunk = stream.read(chunk_size)
-            if not chunk:
-                break
-            if isinstance(chunk, str):
-                chunk = chunk.encode("utf-8")
-            hasher.update(chunk)
-
-        # Create proper multihash (0x12 = SHA-256, length = 32 bytes)
-        mh = multihash.encode(hasher.digest(), multihash.SHA2_256)
-        return str(mh.hex())
+        # Create multihash with SHA-256 (code 0x12)
+        mhash = multihash.encode(sha256_hash, multihash.SHA2_256)
+        return str(mhash.hex())
 
     async def _store_metadata(self, document: Document) -> None:
         """Store document metadata to Minio with idempotency check."""
@@ -468,7 +353,7 @@ class MinioDocumentRepository(DocumentRepository):
         try:
             # Check if metadata already exists and is identical (idempotency)
             try:
-                existing_response = self.client.get_object(
+                existing_response = self.repo_client.client.get_object(
                     bucket_name=self.metadata_bucket, object_name=object_name
                 )
                 existing_data = existing_response.read()
@@ -476,83 +361,46 @@ class MinioDocumentRepository(DocumentRepository):
                 existing_response.release_conn()
 
                 if existing_data == metadata_json:
-                    logger.debug(
-                        "MinioDocumentRepository: Metadata already exists "
-                        "with correct data, skipping put (idempotent)",
-                        extra={
-                            "document_id": document.document_id,
-                            "object_name": object_name,
-                        },
+                    self.repo_client.logger.debug(
+                        "Metadata unchanged, skipping storage",
+                        extra={"document_id": document.document_id},
                     )
                     return
-                else:
-                    logger.debug(
-                        "MinioDocumentRepository: Metadata exists with "
-                        "different data, overwriting",
-                        extra={
-                            "document_id": document.document_id,
-                            "object_name": object_name,
-                        },
-                    )
 
             except S3Error as e:
                 if getattr(e, "code", None) == "NoSuchKey":
-                    logger.debug(
-                        "MinioDocumentRepository: Metadata not found, "
-                        "creating new",
-                        extra={
-                            "document_id": document.document_id,
-                            "object_name": object_name,
-                        },
-                    )
+                    # Metadata doesn't exist, continue to store it
+                    pass
                 else:
-                    raise  # Re-raise if it's another S3 error
+                    raise
 
             # Store the metadata
-            data_stream = io.BytesIO(metadata_json)
-            self.client.put_object(
+            self.repo_client.client.put_object(
                 bucket_name=self.metadata_bucket,
                 object_name=object_name,
-                data=data_stream,
+                data=io.BytesIO(metadata_json),
                 length=len(metadata_json),
                 content_type="application/json",
                 metadata={
-                    "document_id": document.document_id,
-                    "status": document.status.value,
-                    "stored_at": datetime.now(timezone.utc).isoformat(),
+                    "content_multihash": document.content_multihash or "",
+                    "original_filename": document.original_filename or "",
                 },
             )
 
-            logger.debug(
-                "MinioDocumentRepository: Metadata stored successfully",
+            self.repo_client.logger.debug(
+                "Metadata stored successfully",
                 extra={
                     "document_id": document.document_id,
-                    "bucket": self.metadata_bucket,
-                    "object_name": object_name,
                     "metadata_size": len(metadata_json),
                 },
             )
 
-        except S3Error as e:
-            logger.error(
-                "MinioDocumentRepository: Failed to store metadata to Minio",
-                extra={
-                    "document_id": document.document_id,
-                    "error": str(e),
-                    "error_type": type(e).__name__,
-                },
-                exc_info=True,
-            )
-            raise
         except Exception as e:
-            logger.error(
-                "MinioDocumentRepository: Unexpected error during metadata "
-                "storage",
+            self.repo_client.logger.error(
+                "Failed to store metadata",
                 extra={
                     "document_id": document.document_id,
                     "error": str(e),
-                    "error_type": type(e).__name__,
                 },
-                exc_info=True,
             )
             raise

--- a/julee_example/repositories/minio/knowledge_service_config.py
+++ b/julee_example/repositories/minio/knowledge_service_config.py
@@ -1,32 +1,42 @@
 """
 Minio implementation of KnowledgeServiceConfigRepository.
 
-This module provides a Minio-based implementation of the KnowledgeServiceConfigRepository
+This module provides a Minio-based implementation of the
+KnowledgeServiceConfigRepository
 protocol that follows the Clean Architecture patterns defined in the
 Fun-Police Framework. It handles knowledge service configuration storage
 as JSON objects in Minio, ensuring idempotency and proper error handling.
 
 The implementation stores knowledge service configurations as JSON objects
 in Minio, following the large payload handling pattern from the architectural
-guidelines. Each configuration is stored with its knowledge_service_id as the key.
+guidelines. Each configuration is stored with its knowledge_service_id as the
+key.
 """
 
 import logging
 from typing import Optional
 
 from julee_example.domain import KnowledgeServiceConfig
-from julee_example.repositories.knowledge_service_config import KnowledgeServiceConfigRepository
+from julee_example.repositories.knowledge_service_config import (
+    KnowledgeServiceConfigRepository,
+)
 from .client import MinioClient, MinioRepositoryMixin
 
 
-class MinioKnowledgeServiceConfigRepository(KnowledgeServiceConfigRepository, MinioRepositoryMixin):
+class MinioKnowledgeServiceConfigRepository(
+    KnowledgeServiceConfigRepository, MinioRepositoryMixin
+):
     """
-    Minio implementation of KnowledgeServiceConfigRepository using Minio for persistence.
+    Minio implementation of KnowledgeServiceConfigRepository using Minio for
+    persistence.
 
-    This implementation stores knowledge service configurations as JSON objects:
-    - Knowledge Service Configs: JSON objects in the "knowledge-service-configs" bucket
+    This implementation stores knowledge service configurations as JSON
+    objects:
+    - Knowledge Service Configs: JSON objects in the
+      "knowledge-service-configs" bucket
 
-    Each configuration is stored with its knowledge_service_id as the object name
+    Each configuration is stored with its knowledge_service_id as the object
+    name
     for efficient retrieval and updates.
     """
 
@@ -37,7 +47,9 @@ class MinioKnowledgeServiceConfigRepository(KnowledgeServiceConfigRepository, Mi
             client: MinioClient protocol implementation (real or fake)
         """
         self.client = client
-        self.logger = logging.getLogger("MinioKnowledgeServiceConfigRepository")
+        self.logger = logging.getLogger(
+            "MinioKnowledgeServiceConfigRepository"
+        )
         self.bucket_name = "knowledge-service-configs"
         self.ensure_buckets_exist(self.bucket_name)
 
@@ -58,7 +70,7 @@ class MinioKnowledgeServiceConfigRepository(KnowledgeServiceConfigRepository, Mi
             model_class=KnowledgeServiceConfig,
             not_found_log_message="Knowledge service config not found",
             error_log_message="Error retrieving knowledge service config",
-            extra_log_data={"knowledge_service_id": knowledge_service_id}
+            extra_log_data={"knowledge_service_id": knowledge_service_id},
         )
 
     async def save(self, knowledge_service: KnowledgeServiceConfig) -> None:
@@ -77,10 +89,12 @@ class MinioKnowledgeServiceConfigRepository(KnowledgeServiceConfigRepository, Mi
             success_log_message="Knowledge service config saved successfully",
             error_log_message="Error saving knowledge service config",
             extra_log_data={
-                "knowledge_service_id": knowledge_service.knowledge_service_id,
-                "name": knowledge_service.name,
+                "knowledge_service_id": (
+                    knowledge_service.knowledge_service_id
+                ),
+                "service_name": knowledge_service.name,
                 "service_api": knowledge_service.service_api.value,
-            }
+            },
         )
 
     async def generate_id(self) -> str:

--- a/julee_example/repositories/minio/knowledge_service_config.py
+++ b/julee_example/repositories/minio/knowledge_service_config.py
@@ -1,0 +1,198 @@
+"""
+Minio implementation of KnowledgeServiceConfigRepository.
+
+This module provides a Minio-based implementation of the KnowledgeServiceConfigRepository
+protocol that follows the Clean Architecture patterns defined in the
+Fun-Police Framework. It handles knowledge service configuration storage
+as JSON objects in Minio, ensuring idempotency and proper error handling.
+
+The implementation stores knowledge service configurations as JSON objects
+in Minio, following the large payload handling pattern from the architectural
+guidelines. Each configuration is stored with its knowledge_service_id as the key.
+"""
+
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from minio.error import S3Error  # type: ignore[import-untyped]
+
+from julee_example.domain import KnowledgeServiceConfig
+from julee_example.repositories.knowledge_service_config import KnowledgeServiceConfigRepository
+from .client import MinioClient
+
+logger = logging.getLogger(__name__)
+
+
+class MinioKnowledgeServiceConfigRepository(KnowledgeServiceConfigRepository):
+    """
+    Minio implementation of KnowledgeServiceConfigRepository using Minio for persistence.
+
+    This implementation stores knowledge service configurations as JSON objects:
+    - Knowledge Service Configs: JSON objects in the "knowledge-service-configs" bucket
+
+    Each configuration is stored with its knowledge_service_id as the object name
+    for efficient retrieval and updates.
+    """
+
+    def __init__(self, client: MinioClient) -> None:
+        """Initialize repository with Minio client.
+
+        Args:
+            client: MinioClient protocol implementation (real or fake)
+        """
+        logger.debug("Initializing MinioKnowledgeServiceConfigRepository")
+
+        self.client = client
+        self.bucket_name = "knowledge-service-configs"
+        self._ensure_bucket_exists()
+
+    def _ensure_bucket_exists(self) -> None:
+        """Ensure the knowledge service config bucket exists."""
+        try:
+            if not self.client.bucket_exists(self.bucket_name):
+                logger.info(
+                    "Creating knowledge service config bucket",
+                    extra={"bucket_name": self.bucket_name},
+                )
+                self.client.make_bucket(self.bucket_name)
+            else:
+                logger.debug(
+                    "Knowledge service config bucket already exists",
+                    extra={"bucket_name": self.bucket_name},
+                )
+        except S3Error as e:
+            logger.error(
+                "Failed to create knowledge service config bucket",
+                extra={"bucket_name": self.bucket_name, "error": str(e)},
+            )
+            raise
+
+    async def get(
+        self, knowledge_service_id: str
+    ) -> Optional[KnowledgeServiceConfig]:
+        """Retrieve a knowledge service configuration by ID.
+
+        Args:
+            knowledge_service_id: Unique knowledge service identifier
+
+        Returns:
+            KnowledgeServiceConfig object if found, None otherwise
+        """
+        logger.debug(
+            "MinioKnowledgeServiceConfigRepository: Attempting to retrieve knowledge service config",
+            extra={
+                "knowledge_service_id": knowledge_service_id,
+                "bucket_name": self.bucket_name,
+            },
+        )
+
+        try:
+            # Get the knowledge service config from Minio
+            response = self.client.get_object(
+                bucket_name=self.bucket_name,
+                object_name=knowledge_service_id
+            )
+            config_data = response.read()
+            response.close()
+            response.release_conn()
+
+            config_json = config_data.decode("utf-8")
+            config_dict = json.loads(config_json)
+
+            logger.info(
+                "MinioKnowledgeServiceConfigRepository: Knowledge service config retrieved successfully",
+                extra={
+                    "knowledge_service_id": knowledge_service_id,
+                    "name": config_dict.get("name"),
+                    "service_api": config_dict.get("service_api"),
+                    "retrieved_at": datetime.now(timezone.utc).isoformat(),
+                },
+            )
+
+            return KnowledgeServiceConfig(**config_dict)
+
+        except S3Error as e:
+            if getattr(e, "code", None) == "NoSuchKey":
+                logger.debug(
+                    "MinioKnowledgeServiceConfigRepository: Knowledge service config not found",
+                    extra={"knowledge_service_id": knowledge_service_id},
+                )
+                return None
+            else:
+                logger.error(
+                    "MinioKnowledgeServiceConfigRepository: Error retrieving knowledge service config",
+                    extra={"knowledge_service_id": knowledge_service_id, "error": str(e)},
+                )
+                raise
+
+    async def save(self, knowledge_service: KnowledgeServiceConfig) -> None:
+        """Save a knowledge service configuration.
+
+        Args:
+            knowledge_service: Complete KnowledgeServiceConfig to save
+        """
+        logger.debug(
+            "MinioKnowledgeServiceConfigRepository: Saving knowledge service config",
+            extra={
+                "knowledge_service_id": knowledge_service.knowledge_service_id,
+                "name": knowledge_service.name,
+                "service_api": knowledge_service.service_api.value,
+            },
+        )
+
+        try:
+            # Update timestamp
+            knowledge_service.updated_at = datetime.now(timezone.utc)
+
+            # Ensure created_at is set for new configs
+            if knowledge_service.created_at is None:
+                knowledge_service.created_at = datetime.now(timezone.utc)
+
+            # Use Pydantic's JSON serialization for proper datetime handling
+            config_json = knowledge_service.model_dump_json()
+
+            self.client.put_object(
+                bucket_name=self.bucket_name,
+                object_name=knowledge_service.knowledge_service_id,
+                data=config_json.encode("utf-8"),
+                length=len(config_json.encode("utf-8")),
+                content_type="application/json",
+            )
+
+            logger.info(
+                "MinioKnowledgeServiceConfigRepository: Knowledge service config saved successfully",
+                extra={
+                    "knowledge_service_id": knowledge_service.knowledge_service_id,
+                    "name": knowledge_service.name,
+                    "service_api": knowledge_service.service_api.value,
+                    "updated_at": knowledge_service.updated_at.isoformat(),
+                },
+            )
+
+        except S3Error as e:
+            logger.error(
+                "MinioKnowledgeServiceConfigRepository: Error saving knowledge service config",
+                extra={
+                    "knowledge_service_id": knowledge_service.knowledge_service_id,
+                    "error": str(e),
+                },
+            )
+            raise
+
+    async def generate_id(self) -> str:
+        """Generate a unique knowledge service identifier.
+
+        Returns:
+            Unique knowledge service ID string
+        """
+        knowledge_service_id = f"ks-{uuid.uuid4()}"
+
+        logger.debug(
+            "MinioKnowledgeServiceConfigRepository: Generated knowledge service ID",
+            extra={"knowledge_service_id": knowledge_service_id},
+        )
+
+        return knowledge_service_id

--- a/julee_example/repositories/minio/knowledge_service_config.py
+++ b/julee_example/repositories/minio/knowledge_service_config.py
@@ -11,19 +11,11 @@ in Minio, following the large payload handling pattern from the architectural
 guidelines. Each configuration is stored with its knowledge_service_id as the key.
 """
 
-import json
-import logging
-import uuid
-from datetime import datetime, timezone
 from typing import Optional
-
-from minio.error import S3Error  # type: ignore[import-untyped]
 
 from julee_example.domain import KnowledgeServiceConfig
 from julee_example.repositories.knowledge_service_config import KnowledgeServiceConfigRepository
-from .client import MinioClient
-
-logger = logging.getLogger(__name__)
+from .client import MinioClient, MinioRepositoryClient
 
 
 class MinioKnowledgeServiceConfigRepository(KnowledgeServiceConfigRepository):
@@ -43,32 +35,9 @@ class MinioKnowledgeServiceConfigRepository(KnowledgeServiceConfigRepository):
         Args:
             client: MinioClient protocol implementation (real or fake)
         """
-        logger.debug("Initializing MinioKnowledgeServiceConfigRepository")
-
-        self.client = client
+        self.repo_client = MinioRepositoryClient(client, "MinioKnowledgeServiceConfigRepository")
         self.bucket_name = "knowledge-service-configs"
-        self._ensure_bucket_exists()
-
-    def _ensure_bucket_exists(self) -> None:
-        """Ensure the knowledge service config bucket exists."""
-        try:
-            if not self.client.bucket_exists(self.bucket_name):
-                logger.info(
-                    "Creating knowledge service config bucket",
-                    extra={"bucket_name": self.bucket_name},
-                )
-                self.client.make_bucket(self.bucket_name)
-            else:
-                logger.debug(
-                    "Knowledge service config bucket already exists",
-                    extra={"bucket_name": self.bucket_name},
-                )
-        except S3Error as e:
-            logger.error(
-                "Failed to create knowledge service config bucket",
-                extra={"bucket_name": self.bucket_name, "error": str(e)},
-            )
-            raise
+        self.repo_client.ensure_buckets_exist(self.bucket_name)
 
     async def get(
         self, knowledge_service_id: str
@@ -81,52 +50,14 @@ class MinioKnowledgeServiceConfigRepository(KnowledgeServiceConfigRepository):
         Returns:
             KnowledgeServiceConfig object if found, None otherwise
         """
-        logger.debug(
-            "MinioKnowledgeServiceConfigRepository: Attempting to retrieve knowledge service config",
-            extra={
-                "knowledge_service_id": knowledge_service_id,
-                "bucket_name": self.bucket_name,
-            },
+        return self.repo_client.get_json_object(
+            bucket_name=self.bucket_name,
+            object_name=knowledge_service_id,
+            model_class=KnowledgeServiceConfig,
+            not_found_log_message="Knowledge service config not found",
+            error_log_message="Error retrieving knowledge service config",
+            extra_log_data={"knowledge_service_id": knowledge_service_id}
         )
-
-        try:
-            # Get the knowledge service config from Minio
-            response = self.client.get_object(
-                bucket_name=self.bucket_name,
-                object_name=knowledge_service_id
-            )
-            config_data = response.read()
-            response.close()
-            response.release_conn()
-
-            config_json = config_data.decode("utf-8")
-            config_dict = json.loads(config_json)
-
-            logger.info(
-                "MinioKnowledgeServiceConfigRepository: Knowledge service config retrieved successfully",
-                extra={
-                    "knowledge_service_id": knowledge_service_id,
-                    "name": config_dict.get("name"),
-                    "service_api": config_dict.get("service_api"),
-                    "retrieved_at": datetime.now(timezone.utc).isoformat(),
-                },
-            )
-
-            return KnowledgeServiceConfig(**config_dict)
-
-        except S3Error as e:
-            if getattr(e, "code", None) == "NoSuchKey":
-                logger.debug(
-                    "MinioKnowledgeServiceConfigRepository: Knowledge service config not found",
-                    extra={"knowledge_service_id": knowledge_service_id},
-                )
-                return None
-            else:
-                logger.error(
-                    "MinioKnowledgeServiceConfigRepository: Error retrieving knowledge service config",
-                    extra={"knowledge_service_id": knowledge_service_id, "error": str(e)},
-                )
-                raise
 
     async def save(self, knowledge_service: KnowledgeServiceConfig) -> None:
         """Save a knowledge service configuration.
@@ -134,53 +65,21 @@ class MinioKnowledgeServiceConfigRepository(KnowledgeServiceConfigRepository):
         Args:
             knowledge_service: Complete KnowledgeServiceConfig to save
         """
-        logger.debug(
-            "MinioKnowledgeServiceConfigRepository: Saving knowledge service config",
-            extra={
+        # Update timestamps
+        self.repo_client.update_timestamps(knowledge_service)
+
+        self.repo_client.put_json_object(
+            bucket_name=self.bucket_name,
+            object_name=knowledge_service.knowledge_service_id,
+            model=knowledge_service,
+            success_log_message="Knowledge service config saved successfully",
+            error_log_message="Error saving knowledge service config",
+            extra_log_data={
                 "knowledge_service_id": knowledge_service.knowledge_service_id,
                 "name": knowledge_service.name,
                 "service_api": knowledge_service.service_api.value,
-            },
+            }
         )
-
-        try:
-            # Update timestamp
-            knowledge_service.updated_at = datetime.now(timezone.utc)
-
-            # Ensure created_at is set for new configs
-            if knowledge_service.created_at is None:
-                knowledge_service.created_at = datetime.now(timezone.utc)
-
-            # Use Pydantic's JSON serialization for proper datetime handling
-            config_json = knowledge_service.model_dump_json()
-
-            self.client.put_object(
-                bucket_name=self.bucket_name,
-                object_name=knowledge_service.knowledge_service_id,
-                data=config_json.encode("utf-8"),
-                length=len(config_json.encode("utf-8")),
-                content_type="application/json",
-            )
-
-            logger.info(
-                "MinioKnowledgeServiceConfigRepository: Knowledge service config saved successfully",
-                extra={
-                    "knowledge_service_id": knowledge_service.knowledge_service_id,
-                    "name": knowledge_service.name,
-                    "service_api": knowledge_service.service_api.value,
-                    "updated_at": knowledge_service.updated_at.isoformat(),
-                },
-            )
-
-        except S3Error as e:
-            logger.error(
-                "MinioKnowledgeServiceConfigRepository: Error saving knowledge service config",
-                extra={
-                    "knowledge_service_id": knowledge_service.knowledge_service_id,
-                    "error": str(e),
-                },
-            )
-            raise
 
     async def generate_id(self) -> str:
         """Generate a unique knowledge service identifier.
@@ -188,11 +87,4 @@ class MinioKnowledgeServiceConfigRepository(KnowledgeServiceConfigRepository):
         Returns:
             Unique knowledge service ID string
         """
-        knowledge_service_id = f"ks-{uuid.uuid4()}"
-
-        logger.debug(
-            "MinioKnowledgeServiceConfigRepository: Generated knowledge service ID",
-            extra={"knowledge_service_id": knowledge_service_id},
-        )
-
-        return knowledge_service_id
+        return self.repo_client.generate_id_with_prefix("ks")

--- a/julee_example/repositories/minio/tests/test_document.py
+++ b/julee_example/repositories/minio/tests/test_document.py
@@ -410,7 +410,7 @@ class TestMinioDocumentRepositoryMultihash:
     ) -> None:
         """Test multihash calculation from stream."""
         content = b"test content for hashing"
-        stream = io.BytesIO(content)
+        stream = ContentStream(io.BytesIO(content))
 
         # Act
         multihash_result = repository._calculate_multihash_from_stream(stream)
@@ -430,7 +430,7 @@ class TestMinioDocumentRepositoryMultihash:
         self, repository: MinioDocumentRepository
     ) -> None:
         """Test multihash calculation from empty stream."""
-        stream = io.BytesIO(b"")
+        stream = ContentStream(io.BytesIO(b""))
 
         # Act
         multihash_result = repository._calculate_multihash_from_stream(stream)

--- a/julee_example/repositories/minio/tests/test_knowledge_service_config.py
+++ b/julee_example/repositories/minio/tests/test_knowledge_service_config.py
@@ -2,8 +2,8 @@
 Tests for MinioKnowledgeServiceConfigRepository implementation.
 
 This module provides comprehensive tests for the Minio-based knowledge service
-configuration repository implementation, using the fake client to avoid external
-dependencies during testing.
+configuration repository implementation, using the fake client to avoid
+external dependencies during testing.
 """
 
 import pytest
@@ -11,7 +11,9 @@ from datetime import datetime, timezone
 
 from julee_example.domain import KnowledgeServiceConfig
 from julee_example.domain.knowledge_service_config import ServiceApi
-from julee_example.repositories.minio.knowledge_service_config import MinioKnowledgeServiceConfigRepository
+from julee_example.repositories.minio.knowledge_service_config import (
+    MinioKnowledgeServiceConfigRepository,
+)
 from .fake_client import FakeMinioClient
 
 
@@ -22,7 +24,9 @@ def fake_client() -> FakeMinioClient:
 
 
 @pytest.fixture
-def knowledge_service_config_repo(fake_client: FakeMinioClient) -> MinioKnowledgeServiceConfigRepository:
+def knowledge_service_config_repo(
+    fake_client: FakeMinioClient,
+) -> MinioKnowledgeServiceConfigRepository:
     """Create knowledge service config repository with fake client."""
     return MinioKnowledgeServiceConfigRepository(fake_client)
 
@@ -51,7 +55,9 @@ class TestMinioKnowledgeServiceConfigRepositoryBasicOperations:
     ) -> None:
         """Test saving and retrieving a knowledge service configuration."""
         # Save knowledge service config
-        await knowledge_service_config_repo.save(sample_knowledge_service_config)
+        await knowledge_service_config_repo.save(
+            sample_knowledge_service_config
+        )
 
         # Retrieve knowledge service config
         retrieved = await knowledge_service_config_repo.get(
@@ -59,24 +65,38 @@ class TestMinioKnowledgeServiceConfigRepositoryBasicOperations:
         )
 
         assert retrieved is not None
-        assert retrieved.knowledge_service_id == sample_knowledge_service_config.knowledge_service_id
+        assert (
+            retrieved.knowledge_service_id
+            == sample_knowledge_service_config.knowledge_service_id
+        )
         assert retrieved.name == sample_knowledge_service_config.name
-        assert retrieved.description == sample_knowledge_service_config.description
-        assert retrieved.service_api == sample_knowledge_service_config.service_api
+        assert (
+            retrieved.description
+            == sample_knowledge_service_config.description
+        )
+        assert (
+            retrieved.service_api
+            == sample_knowledge_service_config.service_api
+        )
         assert retrieved.created_at is not None
         assert retrieved.updated_at is not None
 
     @pytest.mark.asyncio
     async def test_get_nonexistent_knowledge_service_config(
-        self, knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository
+        self,
+        knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository,
     ) -> None:
-        """Test retrieving a non-existent knowledge service config returns None."""
-        result = await knowledge_service_config_repo.get("nonexistent-ks-config")
+        """Test retrieving a non-existent knowledge service config returns
+        None."""
+        result = await knowledge_service_config_repo.get(
+            "nonexistent-ks-config"
+        )
         assert result is None
 
     @pytest.mark.asyncio
     async def test_generate_id(
-        self, knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository
+        self,
+        knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository,
     ) -> None:
         """Test generating unique knowledge service configuration IDs."""
         id1 = await knowledge_service_config_repo.generate_id()
@@ -102,12 +122,18 @@ class TestMinioKnowledgeServiceConfigRepositoryUpdates:
     ) -> None:
         """Test updating a knowledge service configuration."""
         # Save initial config
-        await knowledge_service_config_repo.save(sample_knowledge_service_config)
+        await knowledge_service_config_repo.save(
+            sample_knowledge_service_config
+        )
 
         # Update the config
         sample_knowledge_service_config.name = "Updated Test Service"
-        sample_knowledge_service_config.description = "Updated description for the test service"
-        await knowledge_service_config_repo.save(sample_knowledge_service_config)
+        sample_knowledge_service_config.description = (
+            "Updated description for the test service"
+        )
+        await knowledge_service_config_repo.save(
+            sample_knowledge_service_config
+        )
 
         # Verify update
         retrieved = await knowledge_service_config_repo.get(
@@ -115,8 +141,14 @@ class TestMinioKnowledgeServiceConfigRepositoryUpdates:
         )
         assert retrieved is not None
         assert retrieved.name == "Updated Test Service"
-        assert retrieved.description == "Updated description for the test service"
-        assert retrieved.service_api == sample_knowledge_service_config.service_api
+        assert (
+            retrieved.description
+            == "Updated description for the test service"
+        )
+        assert (
+            retrieved.service_api
+            == sample_knowledge_service_config.service_api
+        )
 
     @pytest.mark.asyncio
     async def test_save_updates_timestamp(
@@ -128,7 +160,9 @@ class TestMinioKnowledgeServiceConfigRepositoryUpdates:
         original_updated_at = sample_knowledge_service_config.updated_at
 
         # Save config
-        await knowledge_service_config_repo.save(sample_knowledge_service_config)
+        await knowledge_service_config_repo.save(
+            sample_knowledge_service_config
+        )
 
         # Retrieve and check timestamp was updated
         retrieved = await knowledge_service_config_repo.get(
@@ -141,7 +175,8 @@ class TestMinioKnowledgeServiceConfigRepositoryUpdates:
 
     @pytest.mark.asyncio
     async def test_save_sets_created_at_for_new_config(
-        self, knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository
+        self,
+        knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository,
     ) -> None:
         """Test that save operations set created_at for new configurations."""
         # Create config without created_at
@@ -175,7 +210,9 @@ class TestMinioKnowledgeServiceConfigRepositoryIdempotency:
     ) -> None:
         """Test that saving the same config multiple times is idempotent."""
         # Save config first time
-        await knowledge_service_config_repo.save(sample_knowledge_service_config)
+        await knowledge_service_config_repo.save(
+            sample_knowledge_service_config
+        )
 
         # Get the config to check initial state
         retrieved1 = await knowledge_service_config_repo.get(
@@ -184,18 +221,30 @@ class TestMinioKnowledgeServiceConfigRepositoryIdempotency:
         assert retrieved1 is not None
         first_updated_at = retrieved1.updated_at
 
-        # Save same config again (should update timestamp but maintain other data)
-        await knowledge_service_config_repo.save(sample_knowledge_service_config)
+        # Save same config again (should update timestamp but maintain other
+        # data)
+        await knowledge_service_config_repo.save(
+            sample_knowledge_service_config
+        )
 
         # Verify config is still there with updated timestamp
         retrieved2 = await knowledge_service_config_repo.get(
             sample_knowledge_service_config.knowledge_service_id
         )
         assert retrieved2 is not None
-        assert retrieved2.knowledge_service_id == sample_knowledge_service_config.knowledge_service_id
+        assert (
+            retrieved2.knowledge_service_id
+            == sample_knowledge_service_config.knowledge_service_id
+        )
         assert retrieved2.name == sample_knowledge_service_config.name
-        assert retrieved2.description == sample_knowledge_service_config.description
-        assert retrieved2.service_api == sample_knowledge_service_config.service_api
+        assert (
+            retrieved2.description
+            == sample_knowledge_service_config.description
+        )
+        assert (
+            retrieved2.service_api
+            == sample_knowledge_service_config.service_api
+        )
         assert retrieved2.updated_at is not None
         assert first_updated_at is not None
         assert retrieved2.updated_at > first_updated_at
@@ -206,7 +255,8 @@ class TestMinioKnowledgeServiceConfigRepositoryServiceApiTypes:
 
     @pytest.mark.asyncio
     async def test_anthropic_service_api(
-        self, knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository
+        self,
+        knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository,
     ) -> None:
         """Test saving and retrieving config with Anthropic service API."""
         config = KnowledgeServiceConfig(
@@ -217,7 +267,9 @@ class TestMinioKnowledgeServiceConfigRepositoryServiceApiTypes:
         )
 
         await knowledge_service_config_repo.save(config)
-        retrieved = await knowledge_service_config_repo.get("ks-anthropic-test")
+        retrieved = await knowledge_service_config_repo.get(
+            "ks-anthropic-test"
+        )
 
         assert retrieved is not None
         assert retrieved.service_api == ServiceApi.ANTHROPIC
@@ -229,7 +281,8 @@ class TestMinioKnowledgeServiceConfigRepositoryRoundtrip:
 
     @pytest.mark.asyncio
     async def test_full_knowledge_service_config_lifecycle(
-        self, knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository
+        self,
+        knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository,
     ) -> None:
         """Test complete knowledge service config lifecycle."""
         # Generate new config ID
@@ -259,16 +312,21 @@ class TestMinioKnowledgeServiceConfigRepositoryRoundtrip:
         final_config = await knowledge_service_config_repo.get(config_id)
         assert final_config is not None
         assert final_config.name == "Updated Lifecycle Service"
-        assert final_config.description == "Updated description after lifecycle test"
+        assert (
+            final_config.description
+            == "Updated description after lifecycle test"
+        )
         assert final_config.service_api == ServiceApi.ANTHROPIC
         assert final_config.created_at is not None
         assert final_config.updated_at is not None
 
     @pytest.mark.asyncio
     async def test_multiple_configs_independence(
-        self, knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository
+        self,
+        knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository,
     ) -> None:
-        """Test that multiple configs are stored and retrieved independently."""
+        """Test that multiple configs are stored and retrieved
+        independently."""
         # Create multiple configs
         config1 = KnowledgeServiceConfig(
             knowledge_service_id="ks-test-1",
@@ -305,13 +363,19 @@ class TestMinioKnowledgeServiceConfigRepositoryRoundtrip:
         config1.name = "Updated Service One"
         await knowledge_service_config_repo.save(config1)
 
-        retrieved1_updated = await knowledge_service_config_repo.get("ks-test-1")
-        retrieved2_unchanged = await knowledge_service_config_repo.get("ks-test-2")
+        retrieved1_updated = await knowledge_service_config_repo.get(
+            "ks-test-1"
+        )
+        retrieved2_unchanged = await knowledge_service_config_repo.get(
+            "ks-test-2"
+        )
 
         assert retrieved1_updated is not None
         assert retrieved2_unchanged is not None
         assert retrieved1_updated.name == "Updated Service One"
-        assert retrieved2_unchanged.name == "Service Two"  # Should be unchanged
+        assert (
+            retrieved2_unchanged.name == "Service Two"
+        )  # Should be unchanged
 
 
 class TestMinioKnowledgeServiceConfigRepositoryEdgeCases:
@@ -319,7 +383,8 @@ class TestMinioKnowledgeServiceConfigRepositoryEdgeCases:
 
     @pytest.mark.asyncio
     async def test_empty_string_id_handling(
-        self, knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository
+        self,
+        knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository,
     ) -> None:
         """Test handling of empty string knowledge service ID."""
         result = await knowledge_service_config_repo.get("")
@@ -327,7 +392,8 @@ class TestMinioKnowledgeServiceConfigRepositoryEdgeCases:
 
     @pytest.mark.asyncio
     async def test_special_characters_in_id(
-        self, knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository
+        self,
+        knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository,
     ) -> None:
         """Test handling knowledge service IDs with special characters."""
         # Note: This test ensures the repository can handle various ID formats

--- a/julee_example/repositories/minio/tests/test_knowledge_service_config.py
+++ b/julee_example/repositories/minio/tests/test_knowledge_service_config.py
@@ -1,0 +1,349 @@
+"""
+Tests for MinioKnowledgeServiceConfigRepository implementation.
+
+This module provides comprehensive tests for the Minio-based knowledge service
+configuration repository implementation, using the fake client to avoid external
+dependencies during testing.
+"""
+
+import pytest
+from datetime import datetime, timezone
+
+from julee_example.domain import KnowledgeServiceConfig
+from julee_example.domain.knowledge_service_config import ServiceApi
+from julee_example.repositories.minio.knowledge_service_config import MinioKnowledgeServiceConfigRepository
+from .fake_client import FakeMinioClient
+
+
+@pytest.fixture
+def fake_client() -> FakeMinioClient:
+    """Create a fresh fake Minio client for each test."""
+    return FakeMinioClient()
+
+
+@pytest.fixture
+def knowledge_service_config_repo(fake_client: FakeMinioClient) -> MinioKnowledgeServiceConfigRepository:
+    """Create knowledge service config repository with fake client."""
+    return MinioKnowledgeServiceConfigRepository(fake_client)
+
+
+@pytest.fixture
+def sample_knowledge_service_config() -> KnowledgeServiceConfig:
+    """Create a sample knowledge service config for testing."""
+    return KnowledgeServiceConfig(
+        knowledge_service_id="ks-test-123",
+        name="Test Anthropic Service",
+        description="A test knowledge service using Anthropic API",
+        service_api=ServiceApi.ANTHROPIC,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+
+class TestMinioKnowledgeServiceConfigRepositoryBasicOperations:
+    """Test basic CRUD operations on knowledge service configurations."""
+
+    @pytest.mark.asyncio
+    async def test_save_and_get_knowledge_service_config(
+        self,
+        knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository,
+        sample_knowledge_service_config: KnowledgeServiceConfig,
+    ) -> None:
+        """Test saving and retrieving a knowledge service configuration."""
+        # Save knowledge service config
+        await knowledge_service_config_repo.save(sample_knowledge_service_config)
+
+        # Retrieve knowledge service config
+        retrieved = await knowledge_service_config_repo.get(
+            sample_knowledge_service_config.knowledge_service_id
+        )
+
+        assert retrieved is not None
+        assert retrieved.knowledge_service_id == sample_knowledge_service_config.knowledge_service_id
+        assert retrieved.name == sample_knowledge_service_config.name
+        assert retrieved.description == sample_knowledge_service_config.description
+        assert retrieved.service_api == sample_knowledge_service_config.service_api
+        assert retrieved.created_at is not None
+        assert retrieved.updated_at is not None
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent_knowledge_service_config(
+        self, knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository
+    ) -> None:
+        """Test retrieving a non-existent knowledge service config returns None."""
+        result = await knowledge_service_config_repo.get("nonexistent-ks-config")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_generate_id(
+        self, knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository
+    ) -> None:
+        """Test generating unique knowledge service configuration IDs."""
+        id1 = await knowledge_service_config_repo.generate_id()
+        id2 = await knowledge_service_config_repo.generate_id()
+
+        assert isinstance(id1, str)
+        assert isinstance(id2, str)
+        assert id1 != id2
+        assert len(id1) > 0
+        assert len(id2) > 0
+        assert id1.startswith("ks-")
+        assert id2.startswith("ks-")
+
+
+class TestMinioKnowledgeServiceConfigRepositoryUpdates:
+    """Test knowledge service configuration update operations."""
+
+    @pytest.mark.asyncio
+    async def test_update_knowledge_service_config(
+        self,
+        knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository,
+        sample_knowledge_service_config: KnowledgeServiceConfig,
+    ) -> None:
+        """Test updating a knowledge service configuration."""
+        # Save initial config
+        await knowledge_service_config_repo.save(sample_knowledge_service_config)
+
+        # Update the config
+        sample_knowledge_service_config.name = "Updated Test Service"
+        sample_knowledge_service_config.description = "Updated description for the test service"
+        await knowledge_service_config_repo.save(sample_knowledge_service_config)
+
+        # Verify update
+        retrieved = await knowledge_service_config_repo.get(
+            sample_knowledge_service_config.knowledge_service_id
+        )
+        assert retrieved is not None
+        assert retrieved.name == "Updated Test Service"
+        assert retrieved.description == "Updated description for the test service"
+        assert retrieved.service_api == sample_knowledge_service_config.service_api
+
+    @pytest.mark.asyncio
+    async def test_save_updates_timestamp(
+        self,
+        knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository,
+        sample_knowledge_service_config: KnowledgeServiceConfig,
+    ) -> None:
+        """Test that save operations update the updated_at timestamp."""
+        original_updated_at = sample_knowledge_service_config.updated_at
+
+        # Save config
+        await knowledge_service_config_repo.save(sample_knowledge_service_config)
+
+        # Retrieve and check timestamp was updated
+        retrieved = await knowledge_service_config_repo.get(
+            sample_knowledge_service_config.knowledge_service_id
+        )
+        assert retrieved is not None
+        assert retrieved.updated_at is not None
+        assert original_updated_at is not None
+        assert retrieved.updated_at > original_updated_at
+
+    @pytest.mark.asyncio
+    async def test_save_sets_created_at_for_new_config(
+        self, knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository
+    ) -> None:
+        """Test that save operations set created_at for new configurations."""
+        # Create config without created_at
+        config = KnowledgeServiceConfig(
+            knowledge_service_id="ks-new-test",
+            name="New Test Service",
+            description="A new test service",
+            service_api=ServiceApi.ANTHROPIC,
+            created_at=None,  # Explicitly set to None
+            updated_at=None,  # Explicitly set to None
+        )
+
+        # Save config
+        await knowledge_service_config_repo.save(config)
+
+        # Retrieve and check timestamps were set
+        retrieved = await knowledge_service_config_repo.get("ks-new-test")
+        assert retrieved is not None
+        assert retrieved.created_at is not None
+        assert retrieved.updated_at is not None
+
+
+class TestMinioKnowledgeServiceConfigRepositoryIdempotency:
+    """Test idempotent operations on knowledge service configurations."""
+
+    @pytest.mark.asyncio
+    async def test_save_idempotency(
+        self,
+        knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository,
+        sample_knowledge_service_config: KnowledgeServiceConfig,
+    ) -> None:
+        """Test that saving the same config multiple times is idempotent."""
+        # Save config first time
+        await knowledge_service_config_repo.save(sample_knowledge_service_config)
+
+        # Get the config to check initial state
+        retrieved1 = await knowledge_service_config_repo.get(
+            sample_knowledge_service_config.knowledge_service_id
+        )
+        assert retrieved1 is not None
+        first_updated_at = retrieved1.updated_at
+
+        # Save same config again (should update timestamp but maintain other data)
+        await knowledge_service_config_repo.save(sample_knowledge_service_config)
+
+        # Verify config is still there with updated timestamp
+        retrieved2 = await knowledge_service_config_repo.get(
+            sample_knowledge_service_config.knowledge_service_id
+        )
+        assert retrieved2 is not None
+        assert retrieved2.knowledge_service_id == sample_knowledge_service_config.knowledge_service_id
+        assert retrieved2.name == sample_knowledge_service_config.name
+        assert retrieved2.description == sample_knowledge_service_config.description
+        assert retrieved2.service_api == sample_knowledge_service_config.service_api
+        assert retrieved2.updated_at is not None
+        assert first_updated_at is not None
+        assert retrieved2.updated_at > first_updated_at
+
+
+class TestMinioKnowledgeServiceConfigRepositoryServiceApiTypes:
+    """Test handling of different service API types."""
+
+    @pytest.mark.asyncio
+    async def test_anthropic_service_api(
+        self, knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository
+    ) -> None:
+        """Test saving and retrieving config with Anthropic service API."""
+        config = KnowledgeServiceConfig(
+            knowledge_service_id="ks-anthropic-test",
+            name="Anthropic Service",
+            description="Service using Anthropic API",
+            service_api=ServiceApi.ANTHROPIC,
+        )
+
+        await knowledge_service_config_repo.save(config)
+        retrieved = await knowledge_service_config_repo.get("ks-anthropic-test")
+
+        assert retrieved is not None
+        assert retrieved.service_api == ServiceApi.ANTHROPIC
+        assert retrieved.service_api.value == "anthropic"
+
+
+class TestMinioKnowledgeServiceConfigRepositoryRoundtrip:
+    """Test full round-trip scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_full_knowledge_service_config_lifecycle(
+        self, knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository
+    ) -> None:
+        """Test complete knowledge service config lifecycle."""
+        # Generate new config ID
+        config_id = await knowledge_service_config_repo.generate_id()
+
+        # Create and save initial config
+        config = KnowledgeServiceConfig(
+            knowledge_service_id=config_id,
+            name="Lifecycle Test Service",
+            description="Testing full lifecycle",
+            service_api=ServiceApi.ANTHROPIC,
+        )
+        await knowledge_service_config_repo.save(config)
+
+        # Retrieve and verify initial state
+        retrieved = await knowledge_service_config_repo.get(config_id)
+        assert retrieved is not None
+        assert retrieved.name == "Lifecycle Test Service"
+        assert retrieved.service_api == ServiceApi.ANTHROPIC
+
+        # Update the configuration
+        config.name = "Updated Lifecycle Service"
+        config.description = "Updated description after lifecycle test"
+        await knowledge_service_config_repo.save(config)
+
+        # Final verification
+        final_config = await knowledge_service_config_repo.get(config_id)
+        assert final_config is not None
+        assert final_config.name == "Updated Lifecycle Service"
+        assert final_config.description == "Updated description after lifecycle test"
+        assert final_config.service_api == ServiceApi.ANTHROPIC
+        assert final_config.created_at is not None
+        assert final_config.updated_at is not None
+
+    @pytest.mark.asyncio
+    async def test_multiple_configs_independence(
+        self, knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository
+    ) -> None:
+        """Test that multiple configs are stored and retrieved independently."""
+        # Create multiple configs
+        config1 = KnowledgeServiceConfig(
+            knowledge_service_id="ks-test-1",
+            name="Service One",
+            description="First test service",
+            service_api=ServiceApi.ANTHROPIC,
+        )
+
+        config2 = KnowledgeServiceConfig(
+            knowledge_service_id="ks-test-2",
+            name="Service Two",
+            description="Second test service",
+            service_api=ServiceApi.ANTHROPIC,
+        )
+
+        # Save both configs
+        await knowledge_service_config_repo.save(config1)
+        await knowledge_service_config_repo.save(config2)
+
+        # Retrieve both and verify independence
+        retrieved1 = await knowledge_service_config_repo.get("ks-test-1")
+        retrieved2 = await knowledge_service_config_repo.get("ks-test-2")
+
+        assert retrieved1 is not None
+        assert retrieved2 is not None
+        assert retrieved1.knowledge_service_id == "ks-test-1"
+        assert retrieved2.knowledge_service_id == "ks-test-2"
+        assert retrieved1.name == "Service One"
+        assert retrieved2.name == "Service Two"
+        assert retrieved1.description == "First test service"
+        assert retrieved2.description == "Second test service"
+
+        # Update one config and verify the other is unchanged
+        config1.name = "Updated Service One"
+        await knowledge_service_config_repo.save(config1)
+
+        retrieved1_updated = await knowledge_service_config_repo.get("ks-test-1")
+        retrieved2_unchanged = await knowledge_service_config_repo.get("ks-test-2")
+
+        assert retrieved1_updated is not None
+        assert retrieved2_unchanged is not None
+        assert retrieved1_updated.name == "Updated Service One"
+        assert retrieved2_unchanged.name == "Service Two"  # Should be unchanged
+
+
+class TestMinioKnowledgeServiceConfigRepositoryEdgeCases:
+    """Test edge cases and error conditions."""
+
+    @pytest.mark.asyncio
+    async def test_empty_string_id_handling(
+        self, knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository
+    ) -> None:
+        """Test handling of empty string knowledge service ID."""
+        result = await knowledge_service_config_repo.get("")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_special_characters_in_id(
+        self, knowledge_service_config_repo: MinioKnowledgeServiceConfigRepository
+    ) -> None:
+        """Test handling knowledge service IDs with special characters."""
+        # Note: This test ensures the repository can handle various ID formats
+        # that might be generated by different ID generation strategies
+        special_id = "ks-test-with-dashes-and-numbers-123"
+
+        config = KnowledgeServiceConfig(
+            knowledge_service_id=special_id,
+            name="Special ID Service",
+            description="Service with special characters in ID",
+            service_api=ServiceApi.ANTHROPIC,
+        )
+
+        await knowledge_service_config_repo.save(config)
+        retrieved = await knowledge_service_config_repo.get(special_id)
+
+        assert retrieved is not None
+        assert retrieved.knowledge_service_id == special_id
+        assert retrieved.name == "Special ID Service"


### PR DESCRIPTION
While there, I took some time to DRY up the minio implementations which had a lot of similar boiler plate. I went with a mixin in the end, so that we can continue having `self.client` accessible for simple use and testing, while also extracting the common functions.