### PR TITLE
Add a base repository protocol to DRY up repository protocols.

### DIFF
--- a/julee_example/examples/anthropic_assemble_data_test.py
+++ b/julee_example/examples/anthropic_assemble_data_test.py
@@ -387,7 +387,7 @@ async def setup_repositories_with_test_data(
     )
 
     # Store test data in repositories
-    await document_repo.store(document)
+    await document_repo.save(document)
     await assembly_spec_repo.save(assembly_spec)
     await ks_config_repo.save(ks_config)
 

--- a/julee_example/repositories/__init__.py
+++ b/julee_example/repositories/__init__.py
@@ -6,6 +6,7 @@ Extract, Assemble, Publish workflow, following the Clean Architecture
 patterns established in the Fun-Police framework.
 """
 
+from .base import BaseRepository
 from .document import DocumentRepository
 from .assembly import AssemblyRepository
 from .assembly_specification import AssemblySpecificationRepository
@@ -14,6 +15,7 @@ from .knowledge_service_query import KnowledgeServiceQueryRepository
 from .policy import PolicyRepository
 
 __all__ = [
+    "BaseRepository",
     "DocumentRepository",
     "AssemblyRepository",
     "AssemblySpecificationRepository",

--- a/julee_example/repositories/assembly.py
+++ b/julee_example/repositories/assembly.py
@@ -27,34 +27,22 @@ In Temporal workflow contexts, these protocols are implemented by workflow
 stubs that delegate to activities for durability and proper error handling.
 """
 
-from typing import Protocol, Optional, runtime_checkable
+from typing import runtime_checkable, Protocol
 from julee_example.domain import Assembly
+from .base import BaseRepository
 
 
 @runtime_checkable
-class AssemblyRepository(Protocol):
+class AssemblyRepository(BaseRepository[Assembly], Protocol):
     """Handles assembly storage and retrieval operations.
 
     This repository manages Assembly entities within the Capture, Extract,
     Assemble, Publish workflow. Each Assembly produces a single assembled
     document.
+
+    Inherits common CRUD operations (get, save, generate_id) from
+    BaseRepository.
     """
-
-    async def get(self, assembly_id: str) -> Optional[Assembly]:
-        """Retrieve an assembly by ID.
-
-        Args:
-            assembly_id: Unique assembly identifier
-
-        Returns:
-            Assembly if found, None otherwise
-
-        Implementation Notes:
-        - Must be idempotent: multiple calls return same result
-        - Should handle missing assemblies gracefully (return None)
-        - Loads complete assembly including assembled_document_id
-        """
-        ...
 
     async def set_assembled_document(
         self, assembly_id: str, document_id: str
@@ -73,41 +61,5 @@ class AssemblyRepository(Protocol):
         - Updates assembly's updated_at timestamp
         - Updates assembly status to COMPLETED if successful
         - Returns complete assembly with assembled_document_id set
-        """
-        ...
-
-    async def save(self, assembly: Assembly) -> None:
-        """Save assembly metadata (status, updated_at, etc.).
-
-        Args:
-            assembly: Assembly entity
-
-        Implementation Notes:
-        - Must be idempotent: saving same assembly state is safe
-        - Should update the updated_at timestamp
-        - Saves complete assembly including assembled_document_id
-        - Use for status changes, metadata updates, etc.
-        """
-        ...
-
-    async def generate_id(self) -> str:
-        """Generate a unique assembly identifier.
-
-        This operation is non-deterministic and must be called from
-        workflow activities, not directly from workflow code.
-
-        Returns:
-            Unique assembly ID string
-
-        Implementation Notes:
-        - Must generate globally unique identifiers
-        - May use UUIDs, database sequences, or distributed ID generators
-        - Should be fast and reliable
-        - Failure here should be rare but handled gracefully
-
-        Workflow Context:
-        In Temporal workflows, this method is implemented as an activity
-        to ensure the generated ID is durably stored and consistent
-        across workflow replays.
         """
         ...

--- a/julee_example/repositories/assembly.py
+++ b/julee_example/repositories/assembly.py
@@ -43,23 +43,3 @@ class AssemblyRepository(BaseRepository[Assembly], Protocol):
     Inherits common CRUD operations (get, save, generate_id) from
     BaseRepository.
     """
-
-    async def set_assembled_document(
-        self, assembly_id: str, document_id: str
-    ) -> Assembly:
-        """Set the assembled document for an assembly.
-
-        Args:
-            assembly_id: ID of the assembly to update
-            document_id: ID of the assembled document produced
-
-        Returns:
-            Updated Assembly with the assembled_document_id set
-
-        Implementation Notes:
-        - Idempotent: setting same document_id multiple times is safe
-        - Updates assembly's updated_at timestamp
-        - Updates assembly status to COMPLETED if successful
-        - Returns complete assembly with assembled_document_id set
-        """
-        ...

--- a/julee_example/repositories/assembly_specification.py
+++ b/julee_example/repositories/assembly_specification.py
@@ -29,74 +29,24 @@ In Temporal workflow contexts, these protocols are implemented by workflow
 stubs that delegate to activities for durability and proper error handling.
 """
 
-from typing import Protocol, Optional, runtime_checkable
+from typing import Protocol, runtime_checkable
 from julee_example.domain import AssemblySpecification
+from .base import BaseRepository
 
 
 @runtime_checkable
-class AssemblySpecificationRepository(Protocol):
+class AssemblySpecificationRepository(
+    BaseRepository[AssemblySpecification], Protocol
+):
     """Handles assembly specification storage and retrieval operations.
 
     This repository manages AssemblySpecification entities within the Capture,
     Extract, Assemble, Publish workflow. Specifications define how to assemble
     documents of specific types, including JSON schemas and knowledge service
     query configurations.
+
+    Inherits common CRUD operations (get, save, generate_id) from
+    BaseRepository.
     """
 
-    async def get(
-        self, assembly_specification_id: str
-    ) -> Optional[AssemblySpecification]:
-        """Retrieve an assembly specification by ID.
-
-        Args:
-            assembly_specification_id: Unique specification identifier
-
-        Returns:
-            AssemblySpecification if found, None otherwise
-
-        Implementation Notes:
-        - Must be idempotent: multiple calls return same result
-        - Should handle missing specifications gracefully (return None)
-        - Must load complete specification including JSON schema and
-          knowledge service queries
-        """
-        ...
-
-    async def save(
-        self, assembly_specification: AssemblySpecification
-    ) -> None:
-        """Save an assembly specification.
-
-        Args:
-            assembly_specification: Complete AssemblySpecification to save
-
-        Implementation Notes:
-        - Must be idempotent: saving same specification state is safe
-        - Should update the updated_at timestamp
-        - Must save complete specification including JSON schema and
-          knowledge service query configurations
-        - Handles both new specifications and updates to existing ones
-        """
-        ...
-
-    async def generate_id(self) -> str:
-        """Generate a unique assembly specification identifier.
-
-        This operation is non-deterministic and must be called from
-        workflow activities, not directly from workflow code.
-
-        Returns:
-            Unique assembly specification ID string
-
-        Implementation Notes:
-        - Must generate globally unique identifiers
-        - May use UUIDs, database sequences, or distributed ID generators
-        - Should be fast and reliable
-        - Failure here should be rare but handled gracefully
-
-        Workflow Context:
-        In Temporal workflows, this method is implemented as an activity
-        to ensure the generated ID is durably stored and consistent
-        across workflow replays.
-        """
-        ...
+    pass

--- a/julee_example/repositories/base.py
+++ b/julee_example/repositories/base.py
@@ -1,0 +1,95 @@
+"""
+Generic base repository protocol for common CRUD operations.
+
+This module defines a generic BaseRepository protocol that captures the common
+patterns shared across all domain repositories in the Capture, Extract,
+Assemble, Publish workflow. This reduces code duplication while maintaining
+type safety and clean interfaces.
+
+All repository operations follow the same principles:
+
+- **Idempotency**: All methods are designed to be idempotent and safe for
+  retry. Multiple calls with the same parameters will produce the same
+  result without unintended side effects.
+
+- **Workflow Safety**: All operations are safe to call from deterministic
+  workflow contexts. Non-deterministic operations (like ID generation) are
+  explicitly delegated to activities.
+
+- **Domain Objects**: Methods accept and return domain objects or primitives,
+  never framework-specific types.
+
+In Temporal workflow contexts, these protocols are implemented by workflow
+stubs that delegate to activities for durability and proper error handling.
+"""
+
+from typing import Protocol, Optional, runtime_checkable, TypeVar
+from pydantic import BaseModel
+
+# Type variable bound to Pydantic BaseModel for domain entities
+T = TypeVar("T", bound=BaseModel)
+
+
+@runtime_checkable
+class BaseRepository(Protocol[T]):
+    """Generic base repository protocol for common CRUD operations.
+
+    This protocol defines the common interface shared by all domain
+    repositories in the system. It uses generics to provide type safety
+    while eliminating code duplication.
+
+    Type Parameter:
+        T: The domain entity type (must extend Pydantic BaseModel)
+    """
+
+    async def get(self, entity_id: str) -> Optional[T]:
+        """Retrieve an entity by ID.
+
+        Args:
+            entity_id: Unique entity identifier
+
+        Returns:
+            Entity if found, None otherwise
+
+        Implementation Notes:
+        - Must be idempotent: multiple calls return same result
+        - Should handle missing entities gracefully (return None)
+        - Loads complete entity with all relationships
+        """
+        ...
+
+    async def save(self, entity: T) -> None:
+        """Save an entity.
+
+        Args:
+            entity: Complete entity to save
+
+        Implementation Notes:
+        - Must be idempotent: saving same entity state is safe
+        - Should update the updated_at timestamp
+        - Must save complete entity with all relationships
+        - Handles both new entities and updates to existing ones
+        """
+        ...
+
+    async def generate_id(self) -> str:
+        """Generate a unique entity identifier.
+
+        This operation is non-deterministic and must be called from
+        workflow activities, not directly from workflow code.
+
+        Returns:
+            Unique entity ID string
+
+        Implementation Notes:
+        - Must generate globally unique identifiers
+        - May use UUIDs, database sequences, or distributed ID generators
+        - Should be fast and reliable
+        - Failure here should be rare but handled gracefully
+
+        Workflow Context:
+        In Temporal workflows, this method is implemented as an activity
+        to ensure the generated ID is durably stored and consistent
+        across workflow replays.
+        """
+        ...

--- a/julee_example/repositories/document.py
+++ b/julee_example/repositories/document.py
@@ -29,82 +29,21 @@ In Temporal workflow contexts, these protocols are implemented by workflow
 stubs that delegate to activities for durability and proper error handling.
 """
 
-from typing import Protocol, Optional, runtime_checkable
+from typing import runtime_checkable, Protocol
 from julee_example.domain import Document
+from .base import BaseRepository
 
 
 @runtime_checkable
-class DocumentRepository(Protocol):
+class DocumentRepository(BaseRepository[Document], Protocol):
     """Handles document storage and retrieval operations.
 
     This repository manages the core document storage and metadata
     operations within the Capture, Extract, Assemble, Publish workflow.
+
+    Inherits common CRUD operations (get, save, generate_id) from
+    BaseRepository. The save method handles both content and metadata
+    storage atomically.
     """
 
-    async def get(self, document_id: str) -> Optional[Document]:
-        """Retrieve a document with metadata and content.
-
-        Args:
-            document_id: Unique document identifier
-
-        Returns:
-            Document object if found, None otherwise
-
-        Implementation Notes:
-        - Must be idempotent: multiple calls return same result
-        - Should handle missing documents gracefully (return None)
-        """
-        ...
-
-    async def update(self, document: Document) -> None:
-        """Update a complete document with content and metadata.
-
-        Args:
-            document: Updated Document object
-
-        Implementation Notes:
-        - Should update the updated_at timestamp in metadata
-        - Must be idempotent (other than the updated_at timestamp in the
-          metadata): updating with same document is safe
-        - If document.multihash differs it must also update the content
-        - Updates both content and metadata atomically
-        """
-        ...
-
-    async def store(self, document: Document) -> None:
-        """Store a new document with its content and metadata.
-
-        Args:
-            document: Document object with ContentStream
-
-        Implementation Notes:
-        - Must be idempotent
-        - Reads content from document.content ContentStream if provided
-        - Must store both content stream and metadata atomically
-        - Must use document id from generate_id call
-        - Entry point for the "Capture" phase of Capture, Extract, Assemble,
-          Publish
-        """
-        ...
-
-    async def generate_id(self) -> str:
-        """Generate a unique document identifier.
-
-        This operation is non-deterministic and must be called from
-        workflow activities, not directly from workflow code.
-
-        Returns:
-            Unique document ID string
-
-        Implementation Notes:
-        - Must generate globally unique identifiers
-        - May use UUIDs, database sequences, or distributed ID generators
-        - Should be fast and reliable
-        - Failure here should be rare but handled gracefully
-
-        Workflow Context:
-        In Temporal workflows, this method is implemented as an activity
-        to ensure the generated ID is durably stored and consistent
-        across workflow replays.
-        """
-        ...
+    pass

--- a/julee_example/repositories/knowledge_service_config.py
+++ b/julee_example/repositories/knowledge_service_config.py
@@ -30,69 +30,23 @@ In Temporal workflow contexts, these protocols are implemented by workflow
 stubs that delegate to activities for durability and proper error handling.
 """
 
-from typing import Protocol, Optional, runtime_checkable
+from typing import Protocol, runtime_checkable
 from julee_example.domain import KnowledgeServiceConfig
+from .base import BaseRepository
 
 
 @runtime_checkable
-class KnowledgeServiceConfigRepository(Protocol):
+class KnowledgeServiceConfigRepository(
+    BaseRepository[KnowledgeServiceConfig], Protocol
+):
     """Handles knowledge service configuration persistence.
 
     This repository manages knowledge service metadata and configuration
     storage within the Capture, Extract, Assemble, Publish workflow.
     External service operations are handled separately by the service layer.
+
+    Inherits common CRUD operations (get, save, generate_id) from
+    BaseRepository.
     """
 
-    async def get(
-        self, knowledge_service_id: str
-    ) -> Optional[KnowledgeServiceConfig]:
-        """Retrieve a knowledge service configuration by ID.
-
-        Args:
-            knowledge_service_id: Unique knowledge service identifier
-
-        Returns:
-            KnowledgeServiceConfig object if found, None otherwise
-
-        Implementation Notes:
-        - Must be idempotent: multiple calls return same result
-        - Should handle missing services gracefully (return None)
-        - Must load complete service configuration
-        """
-        ...
-
-    async def save(self, knowledge_service: KnowledgeServiceConfig) -> None:
-        """Save a knowledge service configuration.
-
-        Args:
-            knowledge_service: Complete KnowledgeServiceConfig to save
-
-        Implementation Notes:
-        - Must be idempotent: saving same service state is safe
-        - Should update the updated_at timestamp
-        - Must save complete service configuration
-        - Handles both new services and updates to existing ones
-        """
-        ...
-
-    async def generate_id(self) -> str:
-        """Generate a unique knowledge service identifier.
-
-        This operation is non-deterministic and must be called from
-        workflow activities, not directly from workflow code.
-
-        Returns:
-            Unique knowledge service ID string
-
-        Implementation Notes:
-        - Must generate globally unique identifiers
-        - May use UUIDs, database sequences, or distributed ID generators
-        - Should be fast and reliable
-        - Failure here should be rare but handled gracefully
-
-        Workflow Context:
-        In Temporal workflows, this method is implemented as an activity
-        to ensure the generated ID is durably stored and consistent
-        across workflow replays.
-        """
-        ...
+    pass

--- a/julee_example/repositories/knowledge_service_query.py
+++ b/julee_example/repositories/knowledge_service_query.py
@@ -20,58 +20,25 @@ prompts, assistant prompts, metadata, and service configurations
 that are used during the assembly process.
 """
 
-from typing import Protocol, runtime_checkable, Optional
+from typing import Protocol, runtime_checkable
 
 from julee_example.domain.assembly_specification import KnowledgeServiceQuery
+from .base import BaseRepository
 
 
 @runtime_checkable
-class KnowledgeServiceQueryRepository(Protocol):
+class KnowledgeServiceQueryRepository(
+    BaseRepository[KnowledgeServiceQuery], Protocol
+):
     """Handles knowledge service query persistence and retrieval.
 
     This repository manages the storage and retrieval of
     KnowledgeServiceQuery domain objects within the Capture, Extract,
     Assemble, Publish workflow. These queries define how to extract
     specific data using external knowledge services during assembly.
+
+    Inherits common CRUD operations (get, save, generate_id) from
+    BaseRepository.
     """
 
-    async def get(self, query_id: str) -> Optional[KnowledgeServiceQuery]:
-        """Retrieve a knowledge service query by ID.
-
-        Args:
-            query_id: Unique query identifier
-
-        Returns:
-            KnowledgeServiceQuery object if found, None otherwise
-
-        Implementation Notes:
-        - Must be idempotent: multiple calls return same result
-        - Should handle missing queries gracefully (return None)
-        """
-        ...
-
-    async def save(self, query: KnowledgeServiceQuery) -> None:
-        """Store or update a knowledge service query.
-
-        Args:
-            query: KnowledgeServiceQuery object to store
-
-        Implementation Notes:
-        - Must be idempotent: saving same query multiple times is safe
-        - Should update the updated_at timestamp
-        - Creates new query if it doesn't exist, updates if it does
-        """
-        ...
-
-    async def generate_id(self) -> str:
-        """Generate a unique query identifier.
-
-        Returns:
-            Unique string identifier for a new query
-
-        Implementation Notes:
-        - Must generate globally unique identifiers
-        - Should be deterministic within the same process for testing
-        - Format should be consistent across implementations
-        """
-        ...
+    pass

--- a/julee_example/repositories/memory/assembly.py
+++ b/julee_example/repositories/memory/assembly.py
@@ -16,7 +16,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Optional, Dict
 
-from julee_example.domain import Assembly, AssemblyStatus
+from julee_example.domain import Assembly
 from julee_example.repositories.assembly import AssemblyRepository
 
 logger = logging.getLogger(__name__)
@@ -71,63 +71,6 @@ class MemoryAssemblyRepository(AssemblyRepository):
         )
 
         return assembly
-
-    async def set_assembled_document(
-        self, assembly_id: str, document_id: str
-    ) -> Assembly:
-        """Set the assembled document for an assembly.
-
-        Args:
-            assembly_id: ID of the assembly to update
-            document_id: ID of the assembled document produced
-
-        Returns:
-            Updated Assembly with the assembled_document_id set
-        """
-        logger.debug(
-            "MemoryAssemblyRepository: Setting assembled document for "
-            "assembly",
-            extra={
-                "assembly_id": assembly_id,
-                "document_id": document_id,
-            },
-        )
-
-        assembly = self._assemblies.get(assembly_id)
-        if assembly is None:
-            raise ValueError(f"Assembly not found: {assembly_id}")
-
-        # Check for idempotency - if document_id already set
-        if assembly.assembled_document_id == document_id:
-            logger.debug(
-                "MemoryAssemblyRepository: Assembled document already set "
-                "to this value, returning unchanged",
-                extra={
-                    "assembly_id": assembly_id,
-                    "document_id": document_id,
-                },
-            )
-            return assembly
-
-        # Update assembly with assembled document
-        assembly_dict = assembly.model_dump()
-        assembly_dict["assembled_document_id"] = document_id
-        assembly_dict["status"] = AssemblyStatus.COMPLETED
-        assembly_dict["updated_at"] = datetime.now(timezone.utc)
-        updated_assembly = Assembly(**assembly_dict)
-
-        # Store updated assembly
-        self._assemblies[assembly_id] = updated_assembly
-
-        logger.info(
-            "MemoryAssemblyRepository: Assembled document set successfully",
-            extra={
-                "assembly_id": assembly_id,
-                "document_id": document_id,
-            },
-        )
-
-        return updated_assembly
 
     async def save(self, assembly: Assembly) -> None:
         """Save assembly metadata (status, updated_at, etc.).

--- a/julee_example/repositories/memory/document.py
+++ b/julee_example/repositories/memory/document.py
@@ -74,41 +74,14 @@ class MemoryDocumentRepository(DocumentRepository):
 
         return document
 
-    async def update(self, document: Document) -> None:
-        """Update a complete document with content and metadata.
+    async def save(self, document: Document) -> None:
+        """Save a document with its content and metadata.
 
         Args:
-            document: Updated Document object
+            document: Document object to save
         """
         logger.debug(
-            "MemoryDocumentRepository: Updating document",
-            extra={"document_id": document.document_id},
-        )
-
-        # Update timestamp
-        document.updated_at = datetime.now(timezone.utc)
-
-        # Store the updated document
-        self._documents[document.document_id] = document
-
-        logger.info(
-            "MemoryDocumentRepository: Document updated successfully",
-            extra={
-                "document_id": document.document_id,
-                "content_length": (
-                    len(document.content.read()) if document.content else 0
-                ),
-            },
-        )
-
-    async def store(self, document: Document) -> None:
-        """Store a new document with its content and metadata.
-
-        Args:
-            document: Document object with ContentStream
-        """
-        logger.debug(
-            "MemoryDocumentRepository: Storing new document",
+            "MemoryDocumentRepository: Saving document",
             extra={"document_id": document.document_id},
         )
 
@@ -122,7 +95,7 @@ class MemoryDocumentRepository(DocumentRepository):
         self._documents[document.document_id] = document
 
         logger.info(
-            "MemoryDocumentRepository: Document stored successfully",
+            "MemoryDocumentRepository: Document saved successfully",
             extra={
                 "document_id": document.document_id,
                 "content_length": (

--- a/julee_example/repositories/minio/assembly.py
+++ b/julee_example/repositories/minio/assembly.py
@@ -51,8 +51,6 @@ class MinioAssemblyRepository(AssemblyRepository, MinioRepositoryMixin):
 
         return assembly
 
-
-
     async def save(self, assembly: Assembly) -> None:
         """Save assembly metadata (status, updated_at, etc.)."""
         # Update timestamp

--- a/julee_example/repositories/minio/assembly.py
+++ b/julee_example/repositories/minio/assembly.py
@@ -11,10 +11,9 @@ the large payload handling pattern from the architectural guidelines.
 """
 
 import logging
-from datetime import datetime, timezone
 from typing import Optional
 
-from julee_example.domain import Assembly, AssemblyStatus
+from julee_example.domain import Assembly
 from julee_example.repositories.assembly import AssemblyRepository
 from .client import MinioClient, MinioRepositoryMixin
 
@@ -52,31 +51,7 @@ class MinioAssemblyRepository(AssemblyRepository, MinioRepositoryMixin):
 
         return assembly
 
-    async def set_assembled_document(
-        self, assembly_id: str, document_id: str
-    ) -> Assembly:
-        """Set the assembled document for an assembly."""
 
-        # Get current assembly
-        assembly = await self.get(assembly_id)
-        if not assembly:
-            raise ValueError(f"Assembly not found: {assembly_id}")
-
-        # Check idempotency - if document_id already set to this value
-        if assembly.assembled_document_id == document_id:
-            return assembly
-
-        # Update assembly with assembled document
-        assembly_dict = assembly.model_dump()
-        assembly_dict["assembled_document_id"] = document_id
-        assembly_dict["status"] = AssemblyStatus.COMPLETED
-        assembly_dict["updated_at"] = datetime.now(timezone.utc)
-        updated_assembly = Assembly(**assembly_dict)
-
-        # Save the updated assembly
-        await self.save(updated_assembly)
-
-        return updated_assembly
 
     async def save(self, assembly: Assembly) -> None:
         """Save assembly metadata (status, updated_at, etc.)."""

--- a/julee_example/repositories/minio/tests/test_assembly.py
+++ b/julee_example/repositories/minio/tests/test_assembly.py
@@ -92,8 +92,6 @@ class TestMinioAssemblyRepositoryBasicOperations:
         assert len(id2) > 0
 
 
-
-
 class TestMinioAssemblyRepositoryDirectCompletion:
     """Test assembly completion using direct field assignment."""
 
@@ -103,7 +101,7 @@ class TestMinioAssemblyRepositoryDirectCompletion:
         assembly_repo: MinioAssemblyRepository,
         sample_assembly: Assembly,
     ) -> None:
-        """Test completing an assembly using direct field assignment + save."""
+        """Test completing assembly using direct field assignment + save."""
         # Save initial assembly
         await assembly_repo.save(sample_assembly)
 
@@ -135,12 +133,12 @@ class TestMinioAssemblyRepositoryDirectCompletion:
 
         first_updated_at = sample_assembly.updated_at
 
-        # "Complete" same assembly again with same values (should be idempotent)
+        # "Complete" same assembly again with same values (idempotent)
         sample_assembly.assembled_document_id = "output-doc-456"
         sample_assembly.status = AssemblyStatus.COMPLETED
         await assembly_repo.save(sample_assembly)
 
-        # Verify state and that updated_at changed (save always updates timestamp)
+        # Verify state and that updated_at changed (save updates timestamp)
         retrieved = await assembly_repo.get(sample_assembly.assembly_id)
         assert retrieved is not None
         assert retrieved.assembled_document_id == "output-doc-456"
@@ -259,7 +257,9 @@ class TestMinioAssemblyRepositoryEdgeCases:
         await assembly_repo.save(sample_assembly)
 
         # Verify final state
-        updated_assembly = await assembly_repo.get(sample_assembly.assembly_id)
+        updated_assembly = await assembly_repo.get(
+            sample_assembly.assembly_id
+        )
         assert updated_assembly is not None
 
         # Verify final state

--- a/julee_example/repositories/minio/tests/test_assembly.py
+++ b/julee_example/repositories/minio/tests/test_assembly.py
@@ -92,100 +92,62 @@ class TestMinioAssemblyRepositoryBasicOperations:
         assert len(id2) > 0
 
 
-class TestMinioAssemblyRepositoryDocumentManagement:
-    """Test assembled document management operations."""
+
+
+class TestMinioAssemblyRepositoryDirectCompletion:
+    """Test assembly completion using direct field assignment."""
 
     @pytest.mark.asyncio
-    async def test_set_assembled_document(
+    async def test_complete_assembly_with_direct_assignment(
         self,
         assembly_repo: MinioAssemblyRepository,
         sample_assembly: Assembly,
     ) -> None:
-        """Test setting assembled document for an assembly."""
-        # Save assembly first
+        """Test completing an assembly using direct field assignment + save."""
+        # Save initial assembly
         await assembly_repo.save(sample_assembly)
 
-        # Set assembled document
-        updated_assembly = await assembly_repo.set_assembled_document(
-            sample_assembly.assembly_id, "output-doc-1"
-        )
+        # Complete assembly using direct assignment (new approach)
+        sample_assembly.assembled_document_id = "output-doc-123"
+        sample_assembly.status = AssemblyStatus.COMPLETED
+        await assembly_repo.save(sample_assembly)
 
-        assert updated_assembly.assembled_document_id == "output-doc-1"
-        assert updated_assembly.status == AssemblyStatus.COMPLETED
-
-        # Verify persistence by retrieving again
+        # Verify completion by retrieving again
         retrieved = await assembly_repo.get(sample_assembly.assembly_id)
         assert retrieved is not None
-        assert retrieved.assembled_document_id == "output-doc-1"
+        assert retrieved.assembled_document_id == "output-doc-123"
         assert retrieved.status == AssemblyStatus.COMPLETED
 
     @pytest.mark.asyncio
-    async def test_set_assembled_document_idempotency(
+    async def test_assembly_completion_idempotency(
         self,
         assembly_repo: MinioAssemblyRepository,
         sample_assembly: Assembly,
     ) -> None:
-        """Test that setting same document_id is idempotent."""
-        # Save assembly first
+        """Test that direct assignment approach maintains idempotency."""
+        # Save initial assembly
         await assembly_repo.save(sample_assembly)
 
-        # Set assembled document first time
-        updated_assembly1 = await assembly_repo.set_assembled_document(
-            sample_assembly.assembly_id, "output-doc-1"
-        )
-        assert updated_assembly1.assembled_document_id == "output-doc-1"
-        assert updated_assembly1.status == AssemblyStatus.COMPLETED
-
-        # Set same document_id again - should be idempotent
-        updated_assembly2 = await assembly_repo.set_assembled_document(
-            sample_assembly.assembly_id, "output-doc-1"
-        )
-        assert updated_assembly2.assembled_document_id == "output-doc-1"
-        assert updated_assembly2.status == AssemblyStatus.COMPLETED
-
-        # Verify persistence - should still have same document
-        retrieved = await assembly_repo.get(sample_assembly.assembly_id)
-        assert retrieved is not None
-        assert retrieved.assembled_document_id == "output-doc-1"
-
-    @pytest.mark.asyncio
-    async def test_set_assembled_document_overwrites_previous(
-        self,
-        assembly_repo: MinioAssemblyRepository,
-        sample_assembly: Assembly,
-    ) -> None:
-        """Test that setting assembled document overwrites previous value."""
-        # Save assembly first
+        # Complete assembly first time
+        sample_assembly.assembled_document_id = "output-doc-456"
+        sample_assembly.status = AssemblyStatus.COMPLETED
         await assembly_repo.save(sample_assembly)
 
-        # Set first assembled document
-        updated_assembly1 = await assembly_repo.set_assembled_document(
-            sample_assembly.assembly_id, "output-doc-1"
-        )
-        assert updated_assembly1.assembled_document_id == "output-doc-1"
+        first_updated_at = sample_assembly.updated_at
 
-        # Set different assembled document - should overwrite
-        updated_assembly2 = await assembly_repo.set_assembled_document(
-            sample_assembly.assembly_id, "output-doc-2"
-        )
-        assert updated_assembly2.assembled_document_id == "output-doc-2"
-        assert updated_assembly2.status == AssemblyStatus.COMPLETED
+        # "Complete" same assembly again with same values (should be idempotent)
+        sample_assembly.assembled_document_id = "output-doc-456"
+        sample_assembly.status = AssemblyStatus.COMPLETED
+        await assembly_repo.save(sample_assembly)
 
-        # Verify persistence
+        # Verify state and that updated_at changed (save always updates timestamp)
         retrieved = await assembly_repo.get(sample_assembly.assembly_id)
         assert retrieved is not None
-        assert retrieved.assembled_document_id == "output-doc-2"
-
-    @pytest.mark.asyncio
-    async def test_set_assembled_document_for_nonexistent_assembly(
-        self, assembly_repo: MinioAssemblyRepository
-    ) -> None:
-        """Test setting assembled document for non-existent assembly raises
-        error."""
-        with pytest.raises(ValueError, match="Assembly not found"):
-            await assembly_repo.set_assembled_document(
-                "nonexistent-assembly", "doc-123"
-            )
+        assert retrieved.assembled_document_id == "output-doc-456"
+        assert retrieved.status == AssemblyStatus.COMPLETED
+        assert retrieved.updated_at is not None
+        assert first_updated_at is not None
+        assert retrieved.updated_at > first_updated_at
 
 
 class TestMinioAssemblyRepositoryStatusUpdates:
@@ -291,10 +253,14 @@ class TestMinioAssemblyRepositoryEdgeCases:
         sample_assembly.status = AssemblyStatus.IN_PROGRESS
         await assembly_repo.save(sample_assembly)
 
-        # Set assembled document
-        updated_assembly = await assembly_repo.set_assembled_document(
-            sample_assembly.assembly_id, "final-output-doc"
-        )
+        # Set assembled document using direct assignment
+        sample_assembly.assembled_document_id = "final-output-doc"
+        sample_assembly.status = AssemblyStatus.COMPLETED
+        await assembly_repo.save(sample_assembly)
+
+        # Verify final state
+        updated_assembly = await assembly_repo.get(sample_assembly.assembly_id)
+        assert updated_assembly is not None
 
         # Verify final state
         assert updated_assembly.assembled_document_id == "final-output-doc"
@@ -360,9 +326,12 @@ class TestMinioAssemblyRepositoryRoundtrip:
         await assembly_repo.save(assembly)
 
         # Complete assembly with output document
-        final_assembly = await assembly_repo.set_assembled_document(
-            assembly_id, "final-output-document"
-        )
+        assembly.assembled_document_id = "final-output-document"
+        assembly.status = AssemblyStatus.COMPLETED
+        await assembly_repo.save(assembly)
+
+        final_assembly = await assembly_repo.get(assembly_id)
+        assert final_assembly is not None
 
         # Final verification
         assert final_assembly.status == AssemblyStatus.COMPLETED

--- a/julee_example/repositories/minio/tests/test_document.py
+++ b/julee_example/repositories/minio/tests/test_document.py
@@ -133,7 +133,7 @@ class TestMinioDocumentRepositoryStore:
         assert fake_minio_client.get_object_count("documents-content") == 0
 
         # Act
-        await repository.store(sample_document)
+        await repository.save(sample_document)
 
         # Assert content and metadata were stored
         assert fake_minio_client.get_object_count("documents") == 1
@@ -157,7 +157,7 @@ class TestMinioDocumentRepositoryStore:
         repository = MinioDocumentRepository(fake_minio_client)
 
         # Store first document
-        await repository.store(sample_document)
+        await repository.save(sample_document)
 
         # Verify first document was stored with correct multihash
         stored_multihash = sample_document.content_multihash
@@ -178,7 +178,7 @@ class TestMinioDocumentRepositoryStore:
         )
 
         # Store second document - should reuse existing content
-        await repository.store(second_document)
+        await repository.save(second_document)
 
         # Assert: 2 metadata objects, but only 1 content object (worked)
         assert fake_minio_client.get_object_count("documents") == 2
@@ -208,7 +208,7 @@ class TestMinioDocumentRepositoryStore:
         sample_document.content_multihash = "incorrect_hash_12345"
 
         # Act
-        await repository.store(sample_document)
+        await repository.save(sample_document)
 
         # Assert multihash was corrected to the calculated value
         assert sample_document.content_multihash == correct_multihash
@@ -254,7 +254,7 @@ class TestMinioDocumentRepositoryStore:
 
         # Act & Assert
         with pytest.raises(S3Error):
-            await repository.store(sample_document)
+            await repository.save(sample_document)
 
         # Verify no objects were stored
         assert fake_minio_client.get_object_count("documents") == 0
@@ -269,7 +269,7 @@ class TestMinioDocumentRepositoryGet:
     ) -> None:
         """Test retrieving an existing document with content."""
         # Store a document first
-        await repository.store(sample_document)
+        await repository.save(sample_document)
 
         # Act - retrieve the document
         result = await repository.get(sample_document.document_id)
@@ -362,14 +362,14 @@ class TestMinioDocumentRepositoryUpdate:
     ) -> None:
         """Test updating a document."""
         # Store document initially
-        await repository.store(sample_document)
+        await repository.save(sample_document)
         original_updated_at = sample_document.updated_at
 
         # Modify document
         sample_document.status = DocumentStatus.EXTRACTED
 
         # Act
-        await repository.update(sample_document)
+        await repository.save(sample_document)
 
         # Assert updated_at was changed
         assert sample_document.updated_at != original_updated_at
@@ -476,7 +476,7 @@ class TestMinioDocumentRepositoryErrorHandling:
 
         # Act & Assert
         with pytest.raises(S3Error):
-            await repository.store(sample_document)
+            await repository.save(sample_document)
 
         # Verify content was stored but metadata was not
         assert fake_minio_client.get_object_count("documents-content") == 1

--- a/julee_example/repositories/policy.py
+++ b/julee_example/repositories/policy.py
@@ -29,69 +29,21 @@ In Temporal workflow contexts, these protocols are implemented by workflow
 stubs that delegate to activities for durability and proper error handling.
 """
 
-from typing import Protocol, Optional, runtime_checkable
+from typing import runtime_checkable, Protocol
 from julee_example.domain import Policy
+from .base import BaseRepository
 
 
 @runtime_checkable
-class PolicyRepository(Protocol):
+class PolicyRepository(BaseRepository[Policy], Protocol):
     """Handles policy storage and retrieval operations.
 
     This repository manages Policy entities within the Capture, Extract,
     Assemble, Publish workflow. Policies define validation criteria and
     optional transformations for documents in the quality assurance process.
+
+    Inherits common CRUD operations (get, save, generate_id) from
+    BaseRepository.
     """
 
-    async def get(self, policy_id: str) -> Optional[Policy]:
-        """Retrieve a policy by ID.
-
-        Args:
-            policy_id: Unique policy identifier
-
-        Returns:
-            Policy if found, None otherwise
-
-        Implementation Notes:
-        - Must be idempotent: multiple calls return same result
-        - Should handle missing policies gracefully (return None)
-        - Loads complete policy including validation scores and
-          transformation queries
-        """
-        ...
-
-    async def save(self, policy: Policy) -> None:
-        """Save a policy.
-
-        Args:
-            policy: Complete Policy to save
-
-        Implementation Notes:
-        - Must be idempotent: saving same policy state is safe
-        - Should update the updated_at timestamp
-        - Must save complete policy including validation scores and
-          transformation queries
-        - Handles both new policies and updates to existing ones
-        """
-        ...
-
-    async def generate_id(self) -> str:
-        """Generate a unique policy identifier.
-
-        This operation is non-deterministic and must be called from
-        workflow activities, not directly from workflow code.
-
-        Returns:
-            Unique policy ID string
-
-        Implementation Notes:
-        - Must generate globally unique identifiers
-        - May use UUIDs, database sequences, or distributed ID generators
-        - Should be fast and reliable
-        - Failure here should be rare but handled gracefully
-
-        Workflow Context:
-        In Temporal workflows, this method is implemented as an activity
-        to ensure the generated ID is durably stored and consistent
-        across workflow replays.
-        """
-        ...
+    pass

--- a/julee_example/use_cases/extract_assemble_data.py
+++ b/julee_example/use_cases/extract_assemble_data.py
@@ -595,7 +595,7 @@ text or markdown formatting."""
         )
 
         # Save the document
-        await self.document_repo.store(assembled_document)
+        await self.document_repo.save(assembled_document)
 
         return document_id
 

--- a/julee_example/use_cases/extract_assemble_data.py
+++ b/julee_example/use_cases/extract_assemble_data.py
@@ -206,11 +206,9 @@ class ExtractAssembleDataUseCase:
             )
 
             # Step 8: Set the assembled document and return
-            assembly_with_document = (
-                await self.assembly_repo.set_assembled_document(
-                    assembly_id, assembled_document_id
-                )
-            )
+            assembly.assembled_document_id = assembled_document_id
+            assembly.status = AssemblyStatus.COMPLETED
+            await self.assembly_repo.save(assembly)
 
             logger.info(
                 "Assembly completed successfully",
@@ -220,12 +218,11 @@ class ExtractAssembleDataUseCase:
                 },
             )
 
-            return assembly_with_document
+            return assembly
 
         except Exception as e:
             # Mark assembly as failed
             assembly.status = AssemblyStatus.FAILED
-            assembly.updated_at = datetime.now(timezone.utc)
             await self.assembly_repo.save(assembly)
 
             logger.error(

--- a/julee_example/use_cases/tests/test_extract_assemble_data.py
+++ b/julee_example/use_cases/tests/test_extract_assemble_data.py
@@ -192,7 +192,7 @@ class TestExtractAssembleDataUseCase:
             created_at=datetime.now(timezone.utc),
             updated_at=datetime.now(timezone.utc),
         )
-        await document_repo.store(document)
+        await document_repo.save(document)
 
         # Create assembly specification with simple schema
         schema = {
@@ -380,7 +380,7 @@ class TestExtractAssembleDataUseCase:
             created_at=datetime.now(timezone.utc),
             updated_at=datetime.now(timezone.utc),
         )
-        await document_repo.store(document)
+        await document_repo.save(document)
 
         assembly_spec = AssemblySpecification(
             assembly_specification_id="spec-123",
@@ -432,7 +432,7 @@ class TestExtractAssembleDataUseCase:
             created_at=datetime.now(timezone.utc),
             updated_at=datetime.now(timezone.utc),
         )
-        await document_repo.store(document)
+        await document_repo.save(document)
 
         # Create assembly specification with strict schema
         schema = {


### PR DESCRIPTION
Follows #44. As mentioned there, I noticed that we're basically doing the same protocol for all repositories (get, save, generate_id), just returning different types.

This PR adds a base protocol using python generics, so that each specific repository protocol is just a concrete protocol of that generic base.

It required removing the two specific methods, which didn't need to be specific (eg. `DocumentRepository` had an `update` and `store`, which were doing almost the same thing, which could be handled by the save implementation easily).

I'll next do something similar for the minio and memory implementations, which are also duplicating a lot of code.