### PR TITLE
Add DocumentPolicyValidation model.

### DIFF
--- a/julee_example/domain/policy/__init__.py
+++ b/julee_example/domain/policy/__init__.py
@@ -2,8 +2,14 @@ from .policy import (
     Policy,
     PolicyStatus,
 )
+from .document_policy_validation import (
+    DocumentPolicyValidation,
+    DocumentPolicyValidationStatus,
+)
 
 __all__ = [
     "Policy",
     "PolicyStatus",
+    "DocumentPolicyValidation",
+    "DocumentPolicyValidationStatus",
 ]

--- a/julee_example/domain/policy/document_policy_validation.py
+++ b/julee_example/domain/policy/document_policy_validation.py
@@ -1,0 +1,233 @@
+"""
+DocumentPolicyValidation domain models for the Capture, Extract, Assemble,
+Publish workflow.
+
+This module contains the DocumentPolicyValidation domain object that
+represents
+the result of validating a document against a policy configuration in the CEAP
+workflow system.
+
+A DocumentPolicyValidation captures the complete validation process including:
+- The document being validated and the policy used
+- Actual validation scores achieved against policy criteria
+- Optional transformation results and post-transformation scores
+- Status tracking throughout the validation lifecycle
+
+All domain models use Pydantic BaseModel for validation, serialization,
+and type safety, following the patterns established in the sample project.
+"""
+
+from pydantic import BaseModel, Field, field_validator
+from typing import Optional, List, Tuple
+from datetime import datetime, timezone
+from enum import Enum
+
+
+class DocumentPolicyValidationStatus(str, Enum):
+    """Status of a document policy validation process."""
+
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    VALIDATION_COMPLETE = "validation_complete"
+    TRANSFORMATION_REQUIRED = "transformation_required"
+    TRANSFORMATION_IN_PROGRESS = "transformation_in_progress"
+    TRANSFORMATION_COMPLETE = "transformation_complete"
+    PASSED = "passed"
+    FAILED = "failed"
+    ERROR = "error"
+
+
+class DocumentPolicyValidation(BaseModel):
+    """Represents the validation of a document against a policy configuration.
+
+    A DocumentPolicyValidation tracks the complete lifecycle of validating
+    a document against policy criteria. It includes:
+
+    1. Initial validation: Document is scored against policy validation
+       queries
+    2. Optional transformation: If policy includes transformation queries and
+       initial validation fails, transformations are applied
+    3. Re-validation: Transformed document is re-scored against policy
+       criteria
+    4. Final determination: Pass/fail based on final validation scores
+
+    The validation process supports both validation-only policies and policies
+    that include transformations for document quality improvement.
+    """
+
+    # Core validation identification
+    validation_id: Optional[str] = Field(
+        default=None,
+        description="Unique identifier for this validation instance",
+    )
+    input_document_id: str = Field(
+        description="ID of the document being validated against the policy"
+    )
+    policy_id: str = Field(
+        description="ID of the policy configuration used for validation"
+    )
+
+    # Validation process status
+    status: DocumentPolicyValidationStatus = (
+        DocumentPolicyValidationStatus.PENDING
+    )
+
+    # Initial validation results
+    validation_scores: List[Tuple[str, int]] = Field(
+        default_factory=list,
+        description="List of (knowledge_service_query_id, actual_score) "
+        "tuples representing the scores achieved during initial validation. "
+        "Scores are between 0 and 100",
+    )
+
+    # Transformation results (if applicable)
+    transformed_document_id: Optional[str] = Field(
+        default=None,
+        description="ID of the document after transformations have been "
+        "applied. Only present if the policy includes transformation queries "
+        "and they were executed",
+    )
+    post_transform_validation_scores: Optional[List[Tuple[str, int]]] = Field(
+        default=None,
+        description="List of (knowledge_service_query_id, actual_score) "
+        "tuples representing scores achieved after transformation. "
+        "Only present if transformations were applied and re-validation "
+        "occurred",
+    )
+
+    # Validation metadata
+    started_at: Optional[datetime] = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="When the validation process was initiated",
+    )
+    completed_at: Optional[datetime] = Field(
+        default=None, description="When the validation process completed"
+    )
+    error_message: Optional[str] = Field(
+        default=None, description="Error message if validation process failed"
+    )
+
+    # Results summary
+    passed: Optional[bool] = Field(
+        default=None,
+        description="Whether the document passed policy validation. "
+        "None while validation is in progress, True/False when complete",
+    )
+
+    @field_validator("input_document_id")
+    @classmethod
+    def input_document_id_must_not_be_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("Input document ID cannot be empty")
+        return v.strip()
+
+    @field_validator("policy_id")
+    @classmethod
+    def policy_id_must_not_be_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("Policy ID cannot be empty")
+        return v.strip()
+
+    @field_validator("validation_scores")
+    @classmethod
+    def validation_scores_must_be_valid(
+        cls, v: List[Tuple[str, int]]
+    ) -> List[Tuple[str, int]]:
+        if not isinstance(v, list):
+            raise ValueError("Validation scores must be a list")
+
+        # Empty list is valid for pending validations
+        if not v:
+            return v
+
+        return cls._validate_score_tuples(v, "validation_scores")
+
+    @field_validator("post_transform_validation_scores")
+    @classmethod
+    def post_transform_scores_must_be_valid(
+        cls, v: Optional[List[Tuple[str, int]]]
+    ) -> Optional[List[Tuple[str, int]]]:
+        if v is None:
+            return v
+
+        if not isinstance(v, list):
+            raise ValueError(
+                "Post-transform validation scores must be a list or None"
+            )
+
+        # Empty list is valid
+        if not v:
+            return v
+
+        return cls._validate_score_tuples(
+            v, "post_transform_validation_scores"
+        )
+
+    @field_validator("error_message")
+    @classmethod
+    def error_message_must_be_valid(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        if not isinstance(v, str):
+            raise ValueError("Error message must be a string or None")
+        return v.strip() if v.strip() else None
+
+    @field_validator("transformed_document_id")
+    @classmethod
+    def transformed_document_id_must_be_valid(
+        cls, v: Optional[str]
+    ) -> Optional[str]:
+        if v is None:
+            return v
+        if not isinstance(v, str) or not v.strip():
+            raise ValueError(
+                "Transformed document ID must be a non-empty string or None"
+            )
+        return v.strip()
+
+    @classmethod
+    def _validate_score_tuples(
+        cls, scores: List[Tuple[str, int]], field_name: str
+    ) -> List[Tuple[str, int]]:
+        """Helper method to validate score tuple lists."""
+        validated_scores = []
+        query_ids_seen = set()
+
+        for item in scores:
+            if not isinstance(item, tuple) or len(item) != 2:
+                raise ValueError(
+                    f"Each item in {field_name} must be a 2-tuple of "
+                    f"(query_id, actual_score)"
+                )
+
+            query_id, actual_score = item
+
+            # Validate query ID
+            if not isinstance(query_id, str) or not query_id.strip():
+                raise ValueError(
+                    f"Query ID in {field_name} must be a non-empty string"
+                )
+            query_id = query_id.strip()
+
+            # Check for duplicate query IDs within this field
+            if query_id in query_ids_seen:
+                raise ValueError(
+                    f"Duplicate query ID '{query_id}' in {field_name}"
+                )
+            query_ids_seen.add(query_id)
+
+            # Validate actual score
+            if not isinstance(actual_score, int):
+                raise ValueError(
+                    f"Actual score in {field_name} must be an integer "
+                    f"between 0 and 100"
+                )
+            if actual_score < 0 or actual_score > 100:
+                raise ValueError(
+                    f"Actual score {actual_score} in {field_name} must be "
+                    f"between 0 and 100"
+                )
+
+            validated_scores.append((query_id, actual_score))
+
+        return validated_scores

--- a/julee_example/domain/policy/document_policy_validation.py
+++ b/julee_example/domain/policy/document_policy_validation.py
@@ -56,9 +56,8 @@ class DocumentPolicyValidation(BaseModel):
     """
 
     # Core validation identification
-    validation_id: Optional[str] = Field(
-        default=None,
-        description="Unique identifier for this validation instance",
+    validation_id: str = Field(
+        description="Unique identifier for this validation instance"
     )
     input_document_id: str = Field(
         description="ID of the document being validated against the policy"

--- a/julee_example/domain/policy/tests/factories.py
+++ b/julee_example/domain/policy/tests/factories.py
@@ -1,0 +1,47 @@
+"""
+Test factories for Policy domain objects using factory_boy.
+
+This module provides factory_boy factories for creating test instances of
+Policy domain objects with sensible defaults.
+"""
+
+from datetime import datetime, timezone
+from factory.base import Factory
+from factory.faker import Faker
+from factory.declarations import LazyFunction
+
+from julee_example.domain.policy import (
+    DocumentPolicyValidation,
+    DocumentPolicyValidationStatus,
+)
+
+
+class DocumentPolicyValidationFactory(Factory):
+    """Factory for creating DocumentPolicyValidation instances with sensible
+    test defaults."""
+
+    class Meta:
+        model = DocumentPolicyValidation
+
+    # Core validation identification
+    validation_id = Faker("uuid4")
+    input_document_id = Faker("uuid4")
+    policy_id = Faker("uuid4")
+
+    # Validation process status
+    status = DocumentPolicyValidationStatus.PENDING
+
+    # Initial validation results (empty by default)
+    validation_scores: list[tuple[str, int]] = []
+
+    # Transformation results (None by default)
+    transformed_document_id = None
+    post_transform_validation_scores = None
+
+    # Validation metadata
+    started_at = LazyFunction(lambda: datetime.now(timezone.utc))
+    completed_at = None
+    error_message = None
+
+    # Results summary
+    passed = None

--- a/julee_example/domain/policy/tests/test_document_policy_validation.py
+++ b/julee_example/domain/policy/tests/test_document_policy_validation.py
@@ -382,8 +382,6 @@ class TestPostTransformValidationScores:
 class TestDocumentPolicyValidationStatusEnum:
     """Test DocumentPolicyValidationStatus enum usage."""
 
-
-
     def test_default_status_is_pending(self) -> None:
         """Test that default status is PENDING."""
         validation = DocumentPolicyValidation(

--- a/julee_example/domain/policy/tests/test_document_policy_validation.py
+++ b/julee_example/domain/policy/tests/test_document_policy_validation.py
@@ -102,7 +102,9 @@ class TestDocumentPolicyValidationFieldValidation:
         for empty_value in test_cases:
             with pytest.raises(ValidationError) as exc_info:
                 DocumentPolicyValidation(
-                    input_document_id=empty_value, policy_id="policy-456"
+                    validation_id="val-123",
+                    input_document_id=empty_value,
+                    policy_id="policy-456",
                 )
 
             errors = exc_info.value.errors()
@@ -114,7 +116,9 @@ class TestDocumentPolicyValidationFieldValidation:
     def test_input_document_id_strips_whitespace(self) -> None:
         """Test that input_document_id strips whitespace."""
         validation = DocumentPolicyValidation(
-            input_document_id="  doc-123  ", policy_id="policy-456"
+            validation_id="val-123",
+            input_document_id="  doc-123  ",
+            policy_id="policy-456",
         )
         assert validation.input_document_id == "doc-123"
 
@@ -125,7 +129,9 @@ class TestDocumentPolicyValidationFieldValidation:
         for empty_value in test_cases:
             with pytest.raises(ValidationError) as exc_info:
                 DocumentPolicyValidation(
-                    input_document_id="doc-123", policy_id=empty_value
+                    validation_id="val-123",
+                    input_document_id="doc-123",
+                    policy_id=empty_value,
                 )
 
             errors = exc_info.value.errors()
@@ -136,7 +142,9 @@ class TestDocumentPolicyValidationFieldValidation:
     def test_policy_id_strips_whitespace(self) -> None:
         """Test that policy_id strips whitespace."""
         validation = DocumentPolicyValidation(
-            input_document_id="doc-123", policy_id="  policy-456  "
+            validation_id="val-123",
+            input_document_id="doc-123",
+            policy_id="  policy-456  ",
         )
         assert validation.policy_id == "policy-456"
 
@@ -144,6 +152,7 @@ class TestDocumentPolicyValidationFieldValidation:
         """Test transformed_document_id field validation."""
         # None is valid
         validation = DocumentPolicyValidation(
+            validation_id="val-123",
             input_document_id="doc-123",
             policy_id="policy-456",
             transformed_document_id=None,
@@ -152,6 +161,7 @@ class TestDocumentPolicyValidationFieldValidation:
 
         # Non-empty string is valid
         validation = DocumentPolicyValidation(
+            validation_id="val-123",
             input_document_id="doc-123",
             policy_id="policy-456",
             transformed_document_id="doc-123-transformed",
@@ -161,6 +171,7 @@ class TestDocumentPolicyValidationFieldValidation:
         # Empty string should be invalid
         with pytest.raises(ValidationError) as exc_info:
             DocumentPolicyValidation(
+                validation_id="val-123",
                 input_document_id="doc-123",
                 policy_id="policy-456",
                 transformed_document_id="",
@@ -176,6 +187,7 @@ class TestDocumentPolicyValidationFieldValidation:
         """Test error_message field validation."""
         # None is valid
         validation = DocumentPolicyValidation(
+            validation_id="val-123",
             input_document_id="doc-123",
             policy_id="policy-456",
             error_message=None,
@@ -184,6 +196,7 @@ class TestDocumentPolicyValidationFieldValidation:
 
         # Non-empty string is valid
         validation = DocumentPolicyValidation(
+            validation_id="val-123",
             input_document_id="doc-123",
             policy_id="policy-456",
             error_message="Something went wrong",
@@ -192,6 +205,7 @@ class TestDocumentPolicyValidationFieldValidation:
 
         # Empty/whitespace string becomes None
         validation = DocumentPolicyValidation(
+            validation_id="val-123",
             input_document_id="doc-123",
             policy_id="policy-456",
             error_message="   ",
@@ -205,6 +219,7 @@ class TestValidationScores:
     def test_empty_validation_scores_valid(self) -> None:
         """Test that empty validation_scores list is valid."""
         validation = DocumentPolicyValidation(
+            validation_id="val-123",
             input_document_id="doc-123",
             policy_id="policy-456",
             validation_scores=[],
@@ -215,6 +230,7 @@ class TestValidationScores:
         """Test valid validation_scores."""
         scores = [("query1", 85), ("query2", 92), ("query3", 78)]
         validation = DocumentPolicyValidation(
+            validation_id="val-123",
             input_document_id="doc-123",
             policy_id="policy-456",
             validation_scores=scores,
@@ -224,6 +240,7 @@ class TestValidationScores:
     def test_validation_scores_with_valid_integers(self) -> None:
         """Test that validation_scores work with valid integer scores."""
         validation = DocumentPolicyValidation(
+            validation_id="val-123",
             input_document_id="doc-123",
             policy_id="policy-456",
             validation_scores=[("query1", 85), ("query2", 92)],
@@ -238,6 +255,7 @@ class TestValidationScores:
         # Empty query_id should fail
         with pytest.raises(ValidationError) as exc_info:
             DocumentPolicyValidation(
+                validation_id="val-123",
                 input_document_id="doc-123",
                 policy_id="policy-456",
                 validation_scores=[("", 85)],
@@ -251,6 +269,7 @@ class TestValidationScores:
         # Whitespace-only query_id should fail
         with pytest.raises(ValidationError) as exc_info:
             DocumentPolicyValidation(
+                validation_id="val-123",
                 input_document_id="doc-123",
                 policy_id="policy-456",
                 validation_scores=[("   ", 85)],
@@ -266,6 +285,7 @@ class TestValidationScores:
         # Score too low
         with pytest.raises(ValidationError) as exc_info:
             DocumentPolicyValidation(
+                validation_id="val-123",
                 input_document_id="doc-123",
                 policy_id="policy-456",
                 validation_scores=[("query1", -1)],
@@ -279,6 +299,7 @@ class TestValidationScores:
         # Score too high
         with pytest.raises(ValidationError) as exc_info:
             DocumentPolicyValidation(
+                validation_id="val-123",
                 input_document_id="doc-123",
                 policy_id="policy-456",
                 validation_scores=[("query1", 101)],
@@ -291,6 +312,7 @@ class TestValidationScores:
 
         # Valid edge cases
         validation = DocumentPolicyValidation(
+            validation_id="val-123",
             input_document_id="doc-123",
             policy_id="policy-456",
             validation_scores=[("query1", 0), ("query2", 100)],
@@ -304,6 +326,7 @@ class TestValidationScores:
         """Test that validation_scores cannot have duplicate query_ids."""
         with pytest.raises(ValidationError) as exc_info:
             DocumentPolicyValidation(
+                validation_id="val-123",
                 input_document_id="doc-123",
                 policy_id="policy-456",
                 validation_scores=[("query1", 85), ("query1", 92)],
@@ -321,6 +344,7 @@ class TestPostTransformValidationScores:
     def test_none_post_transform_scores_valid(self) -> None:
         """Test that None post_transform_validation_scores is valid."""
         validation = DocumentPolicyValidation(
+            validation_id="val-123",
             input_document_id="doc-123",
             policy_id="policy-456",
             post_transform_validation_scores=None,
@@ -330,6 +354,7 @@ class TestPostTransformValidationScores:
     def test_empty_post_transform_scores_valid(self) -> None:
         """Test that empty post_transform_validation_scores list is valid."""
         validation = DocumentPolicyValidation(
+            validation_id="val-123",
             input_document_id="doc-123",
             policy_id="policy-456",
             post_transform_validation_scores=[],
@@ -340,6 +365,7 @@ class TestPostTransformValidationScores:
         """Test valid post_transform_validation_scores."""
         scores = [("query1", 95), ("query2", 88)]
         validation = DocumentPolicyValidation(
+            validation_id="val-123",
             input_document_id="doc-123",
             policy_id="policy-456",
             post_transform_validation_scores=scores,
@@ -352,6 +378,7 @@ class TestPostTransformValidationScores:
         # Same score range validation
         with pytest.raises(ValidationError) as exc_info:
             DocumentPolicyValidation(
+                validation_id="val-123",
                 input_document_id="doc-123",
                 policy_id="policy-456",
                 post_transform_validation_scores=[("query1", -5)],
@@ -365,6 +392,7 @@ class TestPostTransformValidationScores:
         # Same duplicate detection
         with pytest.raises(ValidationError) as exc_info:
             DocumentPolicyValidation(
+                validation_id="val-123",
                 input_document_id="doc-123",
                 policy_id="policy-456",
                 post_transform_validation_scores=[
@@ -385,7 +413,9 @@ class TestDocumentPolicyValidationStatusEnum:
     def test_default_status_is_pending(self) -> None:
         """Test that default status is PENDING."""
         validation = DocumentPolicyValidation(
-            input_document_id="doc-123", policy_id="policy-456"
+            validation_id="val-123",
+            input_document_id="doc-123",
+            policy_id="policy-456",
         )
         assert validation.status == DocumentPolicyValidationStatus.PENDING
 
@@ -400,6 +430,7 @@ class TestDocumentPolicyValidationStatusEnum:
 
         for status in valid_statuses:
             validation = DocumentPolicyValidation(
+                validation_id="val-123",
                 input_document_id="doc-123",
                 policy_id="policy-456",
                 status=status,

--- a/julee_example/domain/policy/tests/test_document_policy_validation.py
+++ b/julee_example/domain/policy/tests/test_document_policy_validation.py
@@ -1,0 +1,429 @@
+"""
+Tests for DocumentPolicyValidation domain model.
+
+This module tests the DocumentPolicyValidation domain object validation,
+field requirements, and business rules following the same testing patterns
+as the Policy model tests.
+
+Tests focus on:
+- Required field validation
+- Field format validation
+- Score tuple validation
+- Status enum validation
+- Edge cases and error conditions
+"""
+
+import pytest
+from datetime import datetime, timezone
+from pydantic import ValidationError
+
+from julee_example.domain.policy import (
+    DocumentPolicyValidation,
+    DocumentPolicyValidationStatus,
+)
+from .factories import DocumentPolicyValidationFactory
+
+
+class TestDocumentPolicyValidationValidation:
+    """Test validation rules for DocumentPolicyValidation model."""
+
+    def test_minimal_valid_validation(self) -> None:
+        """Test creating a minimal valid DocumentPolicyValidation."""
+        validation = DocumentPolicyValidationFactory()
+
+        assert validation.input_document_id is not None
+        assert validation.policy_id is not None
+        assert validation.status == DocumentPolicyValidationStatus.PENDING
+        assert validation.validation_scores == []
+        assert validation.transformed_document_id is None
+        assert validation.post_transform_validation_scores is None
+        assert validation.validation_id is not None
+        assert validation.passed is None
+        assert validation.error_message is None
+        assert validation.completed_at is None
+        assert isinstance(validation.started_at, datetime)
+
+    def test_full_valid_validation(self) -> None:
+        """Test creating a fully populated DocumentPolicyValidation."""
+        started_at = datetime.now(timezone.utc)
+        completed_at = datetime.now(timezone.utc)
+
+        validation = DocumentPolicyValidation(
+            validation_id="val-789",
+            input_document_id="doc-123",
+            policy_id="policy-456",
+            status=DocumentPolicyValidationStatus.PASSED,
+            validation_scores=[("query1", 85), ("query2", 92)],
+            transformed_document_id="doc-123-transformed",
+            post_transform_validation_scores=[("query1", 95), ("query2", 88)],
+            started_at=started_at,
+            completed_at=completed_at,
+            error_message=None,
+            passed=True,
+        )
+
+        assert validation.validation_id == "val-789"
+        assert validation.input_document_id == "doc-123"
+        assert validation.policy_id == "policy-456"
+        assert validation.status == DocumentPolicyValidationStatus.PASSED
+        assert validation.validation_scores == [
+            ("query1", 85),
+            ("query2", 92),
+        ]
+        assert validation.transformed_document_id == "doc-123-transformed"
+        assert validation.post_transform_validation_scores == [
+            ("query1", 95),
+            ("query2", 88),
+        ]
+        assert validation.started_at == started_at
+        assert validation.completed_at == completed_at
+        assert validation.passed is True
+
+
+class TestDocumentPolicyValidationRequiredFields:
+    """Test required field validation."""
+
+    def test_required_fields_present_in_factory(self) -> None:
+        """Test that factory creates validation with required fields."""
+        validation = DocumentPolicyValidationFactory()
+        assert validation.input_document_id is not None
+        assert validation.policy_id is not None
+        assert isinstance(validation.input_document_id, str)
+        assert isinstance(validation.policy_id, str)
+
+
+class TestDocumentPolicyValidationFieldValidation:
+    """Test individual field validation rules."""
+
+    def test_input_document_id_cannot_be_empty(self) -> None:
+        """Test that input_document_id cannot be empty or whitespace."""
+        test_cases = ["", "   ", "\t", "\n"]
+
+        for empty_value in test_cases:
+            with pytest.raises(ValidationError) as exc_info:
+                DocumentPolicyValidation(
+                    input_document_id=empty_value, policy_id="policy-456"
+                )
+
+            errors = exc_info.value.errors()
+            assert any(
+                "Input document ID cannot be empty" in str(error)
+                for error in errors
+            )
+
+    def test_input_document_id_strips_whitespace(self) -> None:
+        """Test that input_document_id strips whitespace."""
+        validation = DocumentPolicyValidation(
+            input_document_id="  doc-123  ", policy_id="policy-456"
+        )
+        assert validation.input_document_id == "doc-123"
+
+    def test_policy_id_cannot_be_empty(self) -> None:
+        """Test that policy_id cannot be empty or whitespace."""
+        test_cases = ["", "   ", "\t", "\n"]
+
+        for empty_value in test_cases:
+            with pytest.raises(ValidationError) as exc_info:
+                DocumentPolicyValidation(
+                    input_document_id="doc-123", policy_id=empty_value
+                )
+
+            errors = exc_info.value.errors()
+            assert any(
+                "Policy ID cannot be empty" in str(error) for error in errors
+            )
+
+    def test_policy_id_strips_whitespace(self) -> None:
+        """Test that policy_id strips whitespace."""
+        validation = DocumentPolicyValidation(
+            input_document_id="doc-123", policy_id="  policy-456  "
+        )
+        assert validation.policy_id == "policy-456"
+
+    def test_transformed_document_id_validation(self) -> None:
+        """Test transformed_document_id field validation."""
+        # None is valid
+        validation = DocumentPolicyValidation(
+            input_document_id="doc-123",
+            policy_id="policy-456",
+            transformed_document_id=None,
+        )
+        assert validation.transformed_document_id is None
+
+        # Non-empty string is valid
+        validation = DocumentPolicyValidation(
+            input_document_id="doc-123",
+            policy_id="policy-456",
+            transformed_document_id="doc-123-transformed",
+        )
+        assert validation.transformed_document_id == "doc-123-transformed"
+
+        # Empty string should be invalid
+        with pytest.raises(ValidationError) as exc_info:
+            DocumentPolicyValidation(
+                input_document_id="doc-123",
+                policy_id="policy-456",
+                transformed_document_id="",
+            )
+
+        errors = exc_info.value.errors()
+        assert any(
+            "must be a non-empty string or None" in str(error)
+            for error in errors
+        )
+
+    def test_error_message_validation(self) -> None:
+        """Test error_message field validation."""
+        # None is valid
+        validation = DocumentPolicyValidation(
+            input_document_id="doc-123",
+            policy_id="policy-456",
+            error_message=None,
+        )
+        assert validation.error_message is None
+
+        # Non-empty string is valid
+        validation = DocumentPolicyValidation(
+            input_document_id="doc-123",
+            policy_id="policy-456",
+            error_message="Something went wrong",
+        )
+        assert validation.error_message == "Something went wrong"
+
+        # Empty/whitespace string becomes None
+        validation = DocumentPolicyValidation(
+            input_document_id="doc-123",
+            policy_id="policy-456",
+            error_message="   ",
+        )
+        assert validation.error_message is None
+
+
+class TestValidationScores:
+    """Test validation_scores field validation."""
+
+    def test_empty_validation_scores_valid(self) -> None:
+        """Test that empty validation_scores list is valid."""
+        validation = DocumentPolicyValidation(
+            input_document_id="doc-123",
+            policy_id="policy-456",
+            validation_scores=[],
+        )
+        assert validation.validation_scores == []
+
+    def test_valid_validation_scores(self) -> None:
+        """Test valid validation_scores."""
+        scores = [("query1", 85), ("query2", 92), ("query3", 78)]
+        validation = DocumentPolicyValidation(
+            input_document_id="doc-123",
+            policy_id="policy-456",
+            validation_scores=scores,
+        )
+        assert validation.validation_scores == scores
+
+    def test_validation_scores_with_valid_integers(self) -> None:
+        """Test that validation_scores work with valid integer scores."""
+        validation = DocumentPolicyValidation(
+            input_document_id="doc-123",
+            policy_id="policy-456",
+            validation_scores=[("query1", 85), ("query2", 92)],
+        )
+        assert validation.validation_scores == [
+            ("query1", 85),
+            ("query2", 92),
+        ]
+
+    def test_validation_scores_query_id_validation(self) -> None:
+        """Test validation_scores query_id validation."""
+        # Empty query_id should fail
+        with pytest.raises(ValidationError) as exc_info:
+            DocumentPolicyValidation(
+                input_document_id="doc-123",
+                policy_id="policy-456",
+                validation_scores=[("", 85)],
+            )
+
+        errors = exc_info.value.errors()
+        assert any(
+            "must be a non-empty string" in str(error) for error in errors
+        )
+
+        # Whitespace-only query_id should fail
+        with pytest.raises(ValidationError) as exc_info:
+            DocumentPolicyValidation(
+                input_document_id="doc-123",
+                policy_id="policy-456",
+                validation_scores=[("   ", 85)],
+            )
+
+        errors = exc_info.value.errors()
+        assert any(
+            "must be a non-empty string" in str(error) for error in errors
+        )
+
+    def test_validation_scores_score_range(self) -> None:
+        """Test validation_scores score range validation."""
+        # Score too low
+        with pytest.raises(ValidationError) as exc_info:
+            DocumentPolicyValidation(
+                input_document_id="doc-123",
+                policy_id="policy-456",
+                validation_scores=[("query1", -1)],
+            )
+
+        errors = exc_info.value.errors()
+        assert any(
+            "must be between 0 and 100" in str(error) for error in errors
+        )
+
+        # Score too high
+        with pytest.raises(ValidationError) as exc_info:
+            DocumentPolicyValidation(
+                input_document_id="doc-123",
+                policy_id="policy-456",
+                validation_scores=[("query1", 101)],
+            )
+
+        errors = exc_info.value.errors()
+        assert any(
+            "must be between 0 and 100" in str(error) for error in errors
+        )
+
+        # Valid edge cases
+        validation = DocumentPolicyValidation(
+            input_document_id="doc-123",
+            policy_id="policy-456",
+            validation_scores=[("query1", 0), ("query2", 100)],
+        )
+        assert validation.validation_scores == [
+            ("query1", 0),
+            ("query2", 100),
+        ]
+
+    def test_validation_scores_no_duplicates(self) -> None:
+        """Test that validation_scores cannot have duplicate query_ids."""
+        with pytest.raises(ValidationError) as exc_info:
+            DocumentPolicyValidation(
+                input_document_id="doc-123",
+                policy_id="policy-456",
+                validation_scores=[("query1", 85), ("query1", 92)],
+            )
+
+        errors = exc_info.value.errors()
+        assert any(
+            "Duplicate query ID 'query1'" in str(error) for error in errors
+        )
+
+
+class TestPostTransformValidationScores:
+    """Test post_transform_validation_scores field validation."""
+
+    def test_none_post_transform_scores_valid(self) -> None:
+        """Test that None post_transform_validation_scores is valid."""
+        validation = DocumentPolicyValidation(
+            input_document_id="doc-123",
+            policy_id="policy-456",
+            post_transform_validation_scores=None,
+        )
+        assert validation.post_transform_validation_scores is None
+
+    def test_empty_post_transform_scores_valid(self) -> None:
+        """Test that empty post_transform_validation_scores list is valid."""
+        validation = DocumentPolicyValidation(
+            input_document_id="doc-123",
+            policy_id="policy-456",
+            post_transform_validation_scores=[],
+        )
+        assert validation.post_transform_validation_scores == []
+
+    def test_valid_post_transform_scores(self) -> None:
+        """Test valid post_transform_validation_scores."""
+        scores = [("query1", 95), ("query2", 88)]
+        validation = DocumentPolicyValidation(
+            input_document_id="doc-123",
+            policy_id="policy-456",
+            post_transform_validation_scores=scores,
+        )
+        assert validation.post_transform_validation_scores == scores
+
+    def test_post_transform_scores_validation_rules(self) -> None:
+        """Test that post_transform_validation_scores follows same rules as
+        validation_scores."""
+        # Same score range validation
+        with pytest.raises(ValidationError) as exc_info:
+            DocumentPolicyValidation(
+                input_document_id="doc-123",
+                policy_id="policy-456",
+                post_transform_validation_scores=[("query1", -5)],
+            )
+
+        errors = exc_info.value.errors()
+        assert any(
+            "must be between 0 and 100" in str(error) for error in errors
+        )
+
+        # Same duplicate detection
+        with pytest.raises(ValidationError) as exc_info:
+            DocumentPolicyValidation(
+                input_document_id="doc-123",
+                policy_id="policy-456",
+                post_transform_validation_scores=[
+                    ("query1", 85),
+                    ("query1", 92),
+                ],
+            )
+
+        errors = exc_info.value.errors()
+        assert any(
+            "Duplicate query ID 'query1'" in str(error) for error in errors
+        )
+
+
+class TestDocumentPolicyValidationStatusEnum:
+    """Test DocumentPolicyValidationStatus enum usage."""
+
+    def test_all_status_values_valid(self) -> None:
+        """Test that all status enum values are valid."""
+        statuses = [
+            DocumentPolicyValidationStatus.PENDING,
+            DocumentPolicyValidationStatus.IN_PROGRESS,
+            DocumentPolicyValidationStatus.VALIDATION_COMPLETE,
+            DocumentPolicyValidationStatus.TRANSFORMATION_REQUIRED,
+            DocumentPolicyValidationStatus.TRANSFORMATION_IN_PROGRESS,
+            DocumentPolicyValidationStatus.TRANSFORMATION_COMPLETE,
+            DocumentPolicyValidationStatus.PASSED,
+            DocumentPolicyValidationStatus.FAILED,
+            DocumentPolicyValidationStatus.ERROR,
+        ]
+
+        for status in statuses:
+            validation = DocumentPolicyValidation(
+                input_document_id="doc-123",
+                policy_id="policy-456",
+                status=status,
+            )
+            assert validation.status == status
+
+    def test_default_status_is_pending(self) -> None:
+        """Test that default status is PENDING."""
+        validation = DocumentPolicyValidation(
+            input_document_id="doc-123", policy_id="policy-456"
+        )
+        assert validation.status == DocumentPolicyValidationStatus.PENDING
+
+    def test_all_valid_statuses_work(self) -> None:
+        """Test that all valid status enum values work correctly."""
+        valid_statuses = [
+            DocumentPolicyValidationStatus.PENDING,
+            DocumentPolicyValidationStatus.IN_PROGRESS,
+            DocumentPolicyValidationStatus.PASSED,
+            DocumentPolicyValidationStatus.FAILED,
+        ]
+
+        for status in valid_statuses:
+            validation = DocumentPolicyValidation(
+                input_document_id="doc-123",
+                policy_id="policy-456",
+                status=status,
+            )
+            assert validation.status == status

--- a/julee_example/domain/policy/tests/test_document_policy_validation.py
+++ b/julee_example/domain/policy/tests/test_document_policy_validation.py
@@ -382,27 +382,7 @@ class TestPostTransformValidationScores:
 class TestDocumentPolicyValidationStatusEnum:
     """Test DocumentPolicyValidationStatus enum usage."""
 
-    def test_all_status_values_valid(self) -> None:
-        """Test that all status enum values are valid."""
-        statuses = [
-            DocumentPolicyValidationStatus.PENDING,
-            DocumentPolicyValidationStatus.IN_PROGRESS,
-            DocumentPolicyValidationStatus.VALIDATION_COMPLETE,
-            DocumentPolicyValidationStatus.TRANSFORMATION_REQUIRED,
-            DocumentPolicyValidationStatus.TRANSFORMATION_IN_PROGRESS,
-            DocumentPolicyValidationStatus.TRANSFORMATION_COMPLETE,
-            DocumentPolicyValidationStatus.PASSED,
-            DocumentPolicyValidationStatus.FAILED,
-            DocumentPolicyValidationStatus.ERROR,
-        ]
 
-        for status in statuses:
-            validation = DocumentPolicyValidation(
-                input_document_id="doc-123",
-                policy_id="policy-456",
-                status=status,
-            )
-            assert validation.status == status
 
     def test_default_status_is_pending(self) -> None:
         """Test that default status is PENDING."""


### PR DESCRIPTION
Adds the `DocumentPolicyValidation` model which records a policies validation against a document, both for validation-only policies, and transformation policies.