### PR TITLE
Use `temporal_workflow_proxy` decorator in sample

### DIFF
--- a/cal/worker.py
+++ b/cal/worker.py
@@ -190,9 +190,7 @@ async def run_worker(
     temporal_local_config_repo = TemporalLocalCalendarConfigurationRepository(
         repository=local_config_repo_instance
     )
-    temporal_file_storage_repo = TemporalMinioFileStorageRepository(
-        file_storage_repo=minio_file_storage_repo_instance
-    )
+    temporal_file_storage_repo = TemporalMinioFileStorageRepository()
 
     # Initialize Google Calendar repository if credentials available
     temporal_google_calendar_repo = None

--- a/fun-police/systemPatterns.org
+++ b/fun-police/systemPatterns.org
@@ -94,25 +94,24 @@ class PaymentRepository(Protocol):
    - Contains implementation logic for data persistence, service integration, etc.
    - may be non-deterministic, but must be idempotent
 
-2. *Temporal Activity Implementation* (=sample/repos/temporal/__init__.py=):
+2. *Temporal Activity Implementation* (=sample/repos/activities.py=):
    - Created using =@temporal_activity_registration= decorator.
    - Automatically wraps all async methods with =@activity.defn=
    - Imported and instantiated in worker for registration
 
 3. *Workflow Proxy* (=sample/repos/temporal/proxies/payment.py=):
+   - Created using =@temporal_workflow_proxy= decorator
+   - Automatically generates methods that call =workflow.execute_activity()=
    - Used inside workflows for determinism
-   - Calls =workflow.execute_activity()=
    - No actual business logic
    - Ensures workflow replay safety
 
 *Decorator Implementation Details*:
 
-The =@temporal_activity_registration= decorator creates explicit Temporal Activity classes.
-The recommended approach is to define these classes in the temporal package's
-=__init__.py= file for clarity:
+The =@temporal_activity_registration= decorator creates explicit Temporal Activity classes:
 
 #+BEGIN_SRC python
-# In sample/repos/temporal/__init__.py
+# In sample/repos/activities.py
 from util.repos.temporal.decorators import temporal_activity_registration
 from sample.repos.minio.payment import MinioPaymentRepository
 
@@ -125,22 +124,52 @@ class TemporalMinioPaymentRepository(MinioPaymentRepository):
     pass
 
 # In sample/worker.py - Simple import and instantiation
-from sample.repos.temporal import TemporalMinioPaymentRepository
+from sample.repos.activities import TemporalMinioPaymentRepository
 
 temporal_payment_repo = TemporalMinioPaymentRepository(endpoint=minio_endpoint)
 #+END_SRC
 
+The =@temporal_workflow_proxy= decorator creates workflow proxy classes:
+
+#+BEGIN_SRC python
+# In sample/repos/temporal/proxies/payment.py
+from util.repos.temporal.decorators import temporal_workflow_proxy
+from sample.repositories import PaymentRepository
+
+@temporal_workflow_proxy(
+    "sample.payment_repo.minio",
+    default_timeout_seconds=10,
+    retry_methods=["process_payment", "refund_payment"]
+)
+class WorkflowPaymentRepositoryProxy(PaymentRepository):
+    """
+    Workflow proxy that delegates to Temporal activities.
+    All protocol methods automatically implemented.
+    """
+    pass
+
+# In workflows - Simple instantiation
+payment_repo = WorkflowPaymentRepositoryProxy()  # type: ignore[abstract]
+#+END_SRC
+
 *Key Benefits*:
-- Eliminates ~200+ lines of boilerplate delegation code
-- Clear, explicit class definitions in dedicated module
-- Automatically wraps all public async methods as activities
+- Eliminates ~400+ lines of boilerplate delegation code
+- Clear, explicit class definitions in dedicated modules
+- Automatically wraps all protocol methods as activities/proxies
 - Generates consistent activity names: =prefix.method_name=
 - Self-contained worker setup - all Temporal concerns explicit
+- Automatic Pydantic validation for return values
+- Configurable timeouts and retry policies
 
 *Activity Name Generation*:
 - =process_payment= → =sample.payment_repo.minio.process_payment=
 - =get_payment= → =sample.payment_repo.minio.get_payment=
 - =refund_payment= → =sample.payment_repo.minio.refund_payment=
+
+*Type Safety Note*:
+Workflow proxy instantiation requires =# type: ignore[abstract]= because mypy
+cannot statically analyze decorator-generated methods. This is the standard
+pattern for dynamic code generation decorators.
 
 *** 3. Temporal Workflow Determinism Pattern
 
@@ -150,11 +179,17 @@ temporal_payment_repo = TemporalMinioPaymentRepository(endpoint=minio_endpoint)
 class OrderFulfillmentWorkflow:
     @workflow.run
     async def run(self, request_dict: dict) -> OrderStatusResponse:
-        # Create deterministic proxies
-        payment_repo = WorkflowPaymentRepositoryProxy()
+        # Create deterministic proxies using decorator-generated classes
+        payment_repo = WorkflowPaymentRepositoryProxy()  # type: ignore[abstract]
+        inventory_repo = WorkflowInventoryRepositoryProxy()  # type: ignore[abstract]
+        order_repo = WorkflowOrderRepositoryProxy()  # type: ignore[abstract]
 
         # Use case remains unaware of Temporal
-        use_case = OrderFulfillmentUseCase(payment_repo=payment_repo)
+        use_case = OrderFulfillmentUseCase(
+            payment_repo=payment_repo,
+            inventory_repo=inventory_repo,
+            order_repo=order_repo
+        )
 
         # Business logic execution
         return await use_case.fulfill_order(request, request_id)
@@ -457,19 +492,20 @@ class CreateScheduleUseCase:
 
 *Implementation Pattern*:
 #+BEGIN_SRC python
-# Activity Definition
-@activity.defn(name="cal.calendar_sync.source_repo.get_changes")
-async def get_changes(self, calendar_id: str, sync_state: Optional[SyncState]) -> CalendarChanges:
-    return await self.concrete_repo.get_changes(calendar_id, sync_state)
+# Activity Definition (using decorator)
+@temporal_activity_registration("cal.calendar_sync.source_repo")
+class TemporalCalendarSyncSourceRepository(ConcreteCalendarRepository):
+    """Activity wrapper - automatically creates cal.calendar_sync.source_repo.get_changes"""
+    pass
 
-# Workflow Proxy
+# Workflow Proxy (using decorator)
+@temporal_workflow_proxy("cal.calendar_sync.source_repo", default_timeout_seconds=30)
 class CalendarSyncSourceRepositoryProxy(CalendarRepository):
-    async def get_changes(self, calendar_id: str, sync_state: Optional[SyncState]):
-        return await workflow.execute_activity(
-            "cal.calendar_sync.source_repo.get_changes",
-            (calendar_id, sync_state),
-            start_to_close_timeout=self.activity_timeout,
-        )
+    """Proxy class - automatically implements get_changes() method"""
+    pass
+
+# Usage in workflow
+source_repo = CalendarSyncSourceRepositoryProxy()  # type: ignore[abstract]
 #+END_SRC
 
 *Benefits*:
@@ -482,9 +518,10 @@ class CalendarSyncSourceRepositoryProxy(CalendarRepository):
 *Implementation Requirements*:
 - All Temporal activities must follow this naming convention
 - Use case constructor parameters define the semantic roles
-- Activity registration maps parameter names to activity names
-- Workflow proxies use identical naming for `workflow.execute_activity()` calls
+- =@temporal_activity_registration= decorator maps parameter names to activity prefixes
+- =@temporal_workflow_proxy= decorator uses identical naming for activity calls
 - No implementation details (google, postgresql, etc.) in activity names
+- Both decorators must use the same activity base name for consistency
 
 This pattern collection enables building complex, distributed, long-running workflows
 while maintaining clean architecture principles and ensuring system reliability

--- a/sample/api/dependencies.py
+++ b/sample/api/dependencies.py
@@ -93,13 +93,11 @@ async def get_minio_order_request_repository() -> OrderRequestRepository:
 
 async def get_temporal_file_storage_repository() -> FileStorageRepository:
     """FastAPI dependency for FileStorageRepository."""
-    from util.repos.minio.file_storage import MinioFileStorageRepository
     from util.repos.temporal.minio_file_storage import (
         TemporalMinioFileStorageRepository,
     )
 
-    minio_repo = MinioFileStorageRepository()
-    return TemporalMinioFileStorageRepository(minio_repo)
+    return TemporalMinioFileStorageRepository()
 
 
 def _get_minio_endpoint() -> str:

--- a/sample/repos/temporal/proxies/inventory.py
+++ b/sample/repos/temporal/proxies/inventory.py
@@ -5,18 +5,15 @@ It ensures workflow determinism by delegating all non-deterministic
 operations to activities.
 """
 
-import logging
-from typing import List
-
-from temporalio import workflow
-from temporalio.common import RetryPolicy
-
-from sample.domain import Order, InventoryItem, InventoryReservationOutcome
+from util.repos.temporal.decorators import temporal_workflow_proxy
 from sample.repositories import InventoryRepository
 
-logger = logging.getLogger(__name__)
 
-
+@temporal_workflow_proxy(
+    "sample.inventory_repo.minio",
+    default_timeout_seconds=10,
+    retry_methods=["reserve_items"],
+)
 class WorkflowInventoryRepositoryProxy(InventoryRepository):
     """
     Workflow implementation of InventoryRepository that calls activities.
@@ -24,89 +21,4 @@ class WorkflowInventoryRepositoryProxy(InventoryRepository):
     performed via Temporal activities, maintaining workflow determinism.
     """
 
-    def __init__(self) -> None:
-        self.activity_timeout = workflow.timedelta(seconds=10)
-        self.activity_fail_fast_retry_policy = RetryPolicy(
-            initial_interval=workflow.timedelta(seconds=1),
-            maximum_attempts=1,
-            backoff_coefficient=1.0,
-            maximum_interval=workflow.timedelta(seconds=1),
-        )
-        logger.debug("Initialized WorkflowInventoryRepositoryProxy")
-
-    async def reserve_items(
-        self, order: Order
-    ) -> InventoryReservationOutcome:
-        """Reserve inventory items by executing an activity."""
-        logger.debug(
-            "Workflow: Calling reserve_items activity",
-            extra={
-                "order_id": order.order_id,
-                "item_count": len(order.items),
-            },
-        )
-
-        # The activity returns a Pydantic model, but Temporal's data converter
-        # might deserialize it as a dict in the workflow context.
-        # Explicitly re-validate to ensure it's a Pydantic model.
-        raw_result = await workflow.execute_activity(
-            "sample.inventory_repo.minio.reserve_items",
-            order,
-            start_to_close_timeout=self.activity_timeout,
-            retry_policy=self.activity_fail_fast_retry_policy,
-        )
-        result = InventoryReservationOutcome.model_validate(raw_result)
-
-        logger.debug(
-            "Workflow: reserve_items activity completed",
-            extra={
-                "order_id": order.order_id,
-                "result_type": type(result).__name__,
-                "result_count": (
-                    len(result.reserved_items) if result.reserved_items else 0
-                ),
-            },
-        )
-
-        return result
-
-    async def release_items(self, order: Order) -> List[InventoryItem]:
-        """Release previously reserved inventory items by executing an
-        activity.
-        """
-        logger.debug(
-            "Workflow: Calling release_items activity",
-            extra={
-                "order_id": order.order_id,
-                "item_count": len(order.items),
-            },
-        )
-
-        # The activity returns a list of Pydantic models, but Temporal's
-        # data converter might deserialize it as a list of dicts in the
-        # workflow context. Explicitly re-validate each item to ensure
-        # they are Pydantic models.
-        raw_results = await workflow.execute_activity(
-            "sample.inventory_repo.minio.release_items",
-            order,
-            start_to_close_timeout=self.activity_timeout,
-        )
-        # Convert each dict in the list back to an InventoryItem Pydantic
-        # model
-        results = [
-            InventoryItem.model_validate(item_data)
-            for item_data in raw_results
-        ]
-
-        logger.debug(
-            "Workflow: release_items activity completed",
-            extra={
-                "order_id": order.order_id,
-                "result_type": type(results).__name__,
-                "result_count": (
-                    len(results) if isinstance(results, list) else 0
-                ),
-            },
-        )
-
-        return results
+    pass

--- a/sample/repos/temporal/proxies/order.py
+++ b/sample/repos/temporal/proxies/order.py
@@ -5,17 +5,13 @@ It ensures workflow determinism by delegating all non-deterministic
 operations to activities.
 """
 
-import logging
-from typing import Optional
-
-from temporalio import workflow
-
-from sample.domain import Order
+from util.repos.temporal.decorators import temporal_workflow_proxy
 from sample.repositories import OrderRepository
 
-logger = logging.getLogger(__name__)
 
-
+@temporal_workflow_proxy(
+    "sample.order_repo.minio", default_timeout_seconds=10
+)
 class WorkflowOrderRepositoryProxy(OrderRepository):
     """
     Workflow implementation of OrderRepository that calls activities.
@@ -23,89 +19,4 @@ class WorkflowOrderRepositoryProxy(OrderRepository):
     performed via Temporal activities, maintaining workflow determinism.
     """
 
-    def __init__(self) -> None:
-        self.activity_timeout = workflow.timedelta(seconds=10)
-        logger.debug("Initialized WorkflowOrderRepositoryProxy")
-
-    async def generate_order_id(self) -> str:
-        """Generate a unique order ID by executing an activity."""
-        logger.debug("Workflow: Calling generate_order_id activity")
-
-        result = await workflow.execute_activity(
-            "sample.order_repo.minio.generate_order_id",
-            start_to_close_timeout=self.activity_timeout,
-        )
-
-        logger.debug(
-            "Workflow: generate_order_id activity completed",
-            extra={"order_id": result},
-        )
-        return result  # type: ignore[no-any-return]
-
-    async def save_order(self, order: Order) -> None:
-        """Persist the state of an order by executing an activity."""
-        logger.debug(
-            "Workflow: Calling save_order activity",
-            extra={"order_id": order.order_id, "status": order.status},
-        )
-        await workflow.execute_activity(
-            "sample.order_repo.minio.save_order",
-            order,
-            start_to_close_timeout=self.activity_timeout,
-        )
-        logger.debug(
-            "Workflow: save_order activity completed",
-            extra={"order_id": order.order_id},
-        )
-
-    async def get_order(self, order_id: str) -> Optional[Order]:
-        """Retrieve an order by its ID by executing an activity."""
-        logger.debug(
-            "Workflow: Calling get_order activity",
-            extra={"order_id": order_id},
-        )
-
-        # The activity returns an Optional[Order] Pydantic model, but
-        # Temporal's data converter might deserialize it as a dict or None
-        # in the workflow context.
-        # Explicitly re-validate if not None.
-        raw_result = await workflow.execute_activity(
-            "sample.order_repo.minio.get_order",
-            order_id,
-            start_to_close_timeout=self.activity_timeout,
-        )
-
-        result = None
-        if raw_result is not None:
-            result = Order.model_validate(raw_result)
-
-        logger.debug(
-            "Workflow: get_order activity completed",
-            extra={
-                "order_id": order_id,
-                "found": result is not None,
-                "result_type": type(result).__name__ if result else None,
-            },
-        )
-        return result
-
-    async def cancel_order(
-        self, order_id: str, reason: Optional[str] = None
-    ) -> None:
-        """Cancel an order by executing an activity."""
-        logger.debug(
-            "Workflow: Calling cancel_order activity",
-            extra={"order_id": order_id, "reason": reason},
-        )
-        await workflow.execute_activity(
-            "sample.order_repo.minio.cancel_order",
-            {
-                "order_id": order_id,
-                "reason": reason,
-            },  # Pass as dict for activity args
-            start_to_close_timeout=self.activity_timeout,
-        )
-        logger.debug(
-            "Workflow: cancel_order activity completed",
-            extra={"order_id": order_id},
-        )
+    pass

--- a/sample/repos/temporal/proxies/order_request.py
+++ b/sample/repos/temporal/proxies/order_request.py
@@ -5,16 +5,13 @@ It ensures workflow determinism by delegating all non-deterministic
 operations to activities.
 """
 
-import logging
-from typing import Optional
-
-from temporalio import workflow
-
+from util.repos.temporal.decorators import temporal_workflow_proxy
 from sample.repositories import OrderRequestRepository
 
-logger = logging.getLogger(__name__)
 
-
+@temporal_workflow_proxy(
+    "sample.order_request_repo.minio", default_timeout_seconds=10
+)
 class WorkflowOrderRequestRepositoryProxy(OrderRequestRepository):
     """
     Workflow implementation of OrderRequestRepository that calls activities.
@@ -23,66 +20,4 @@ class WorkflowOrderRequestRepositoryProxy(OrderRequestRepository):
     maintaining workflow determinism.
     """
 
-    def __init__(self) -> None:
-        self.activity_timeout = workflow.timedelta(seconds=10)
-        logger.debug("Initialized WorkflowOrderRequestRepositoryProxy")
-
-    async def store_bidirectional_mapping(
-        self, request_id: str, order_id: str
-    ) -> None:
-        """Store bidirectional mapping by executing an activity."""
-        logger.debug(
-            "Workflow: Calling store_bidirectional_mapping activity",
-            extra={"request_id": request_id, "order_id": order_id},
-        )
-
-        await workflow.execute_activity(
-            "sample.order_request_repo.minio.store_bidirectional_mapping",
-            args=[request_id, order_id],
-            start_to_close_timeout=self.activity_timeout,
-        )
-
-        logger.info(
-            "Workflow: Bidirectional mapping stored",
-            extra={"request_id": request_id, "order_id": order_id},
-        )
-
-    async def get_order_id_for_request(
-        self, request_id: str
-    ) -> Optional[str]:
-        """Get order ID for a given request ID by executing an activity."""
-        logger.debug(
-            "Workflow: Calling get_order_id_for_request activity",
-            extra={"request_id": request_id},
-        )
-
-        result = await workflow.execute_activity(
-            "sample.order_request_repo.minio.get_order_id_for_request",
-            args=[request_id],
-            start_to_close_timeout=self.activity_timeout,
-        )
-
-        logger.debug(
-            "Workflow: get_order_id_for_request activity completed",
-            extra={"request_id": request_id, "order_id": result},
-        )
-        return result  # type: ignore[no-any-return]
-
-    async def get_request_id_for_order(self, order_id: str) -> Optional[str]:
-        """Get request ID for a given order ID by executing an activity."""
-        logger.debug(
-            "Workflow: Calling get_request_id_for_order activity",
-            extra={"order_id": order_id},
-        )
-
-        result = await workflow.execute_activity(
-            "sample.order_request_repo.minio.get_request_id_for_order",
-            args=[order_id],
-            start_to_close_timeout=self.activity_timeout,
-        )
-
-        logger.debug(
-            "Workflow: get_request_id_for_order activity completed",
-            extra={"order_id": order_id, "request_id": result},
-        )
-        return result  # type: ignore[no-any-return]
+    pass

--- a/sample/repos/temporal/proxies/payment.py
+++ b/sample/repos/temporal/proxies/payment.py
@@ -5,24 +5,15 @@ It ensures workflow determinism by delegating all non-deterministic
 operations to activities.
 """
 
-import logging
-from typing import Optional
-
-from temporalio import workflow
-from temporalio.common import RetryPolicy
-
-from sample.domain import (
-    Order,
-    Payment,
-    PaymentOutcome,
-    RefundPaymentArgs,
-    RefundPaymentOutcome,
-)  # Added RefundPaymentArgs, RefundPaymentOutcome
+from util.repos.temporal.decorators import temporal_workflow_proxy
 from sample.repositories import PaymentRepository
 
-logger = logging.getLogger(__name__)
 
-
+@temporal_workflow_proxy(
+    "sample.payment_repo.minio",
+    default_timeout_seconds=10,
+    retry_methods=["process_payment", "refund_payment"],
+)
 class WorkflowPaymentRepositoryProxy(PaymentRepository):
     """
     Workflow implementation of PaymentRepository that calls activities.
@@ -30,98 +21,4 @@ class WorkflowPaymentRepositoryProxy(PaymentRepository):
     performed via Temporal activities, maintaining workflow determinism.
     """
 
-    def __init__(self) -> None:
-        self.activity_timeout = workflow.timedelta(seconds=10)
-        self.activity_fail_fast_retry_policy = RetryPolicy(
-            initial_interval=workflow.timedelta(seconds=1),
-            maximum_attempts=1,
-            backoff_coefficient=1.0,
-            maximum_interval=workflow.timedelta(seconds=1),
-        )
-        logger.debug("Initialized WorkflowPaymentRepositoryProxy")
-
-    async def process_payment(self, order: Order) -> PaymentOutcome:
-        """Process payment by executing an activity."""
-        logger.debug(
-            "Workflow: Calling process_payment activity",
-            extra={
-                "order_id": order.order_id,
-                "amount": str(order.total_amount),
-            },
-        )
-
-        # The activity returns a Pydantic model, but Temporal's data converter
-        # might deserialize it as a dict in the workflow context.
-        # Explicitly re-validate to ensure it's a Pydantic model.
-        raw_result = await workflow.execute_activity(
-            "sample.payment_repo.minio.process_payment",
-            order,
-            start_to_close_timeout=self.activity_timeout,
-            retry_policy=self.activity_fail_fast_retry_policy,
-        )
-        result = PaymentOutcome.model_validate(raw_result)
-
-        logger.debug(
-            "Workflow: process_payment activity completed",
-            extra={
-                "order_id": order.order_id,
-                "result_type": type(result).__name__,
-            },
-        )
-
-        return result
-
-    async def get_payment(self, payment_id: str) -> Optional[Payment]:
-        """Get payment by ID by executing an activity."""
-        logger.debug(
-            "Workflow: Calling get_payment activity",
-            extra={"payment_id": payment_id},
-        )
-
-        # The activity returns an Optional[Payment] Pydantic model, but
-        # Temporal's data converter might deserialize it as a dict or None
-        # in the workflow context. Explicitly re-validate if not None.
-        raw_result = await workflow.execute_activity(
-            "sample.payment_repo.minio.get_payment",
-            payment_id,
-            start_to_close_timeout=self.activity_timeout,
-        )
-
-        result = None
-        if raw_result is not None:
-            result = Payment.model_validate(raw_result)
-
-        logger.debug(
-            "Workflow: get_payment activity completed",
-            extra={
-                "payment_id": payment_id,
-                "found": result is not None,
-                "result_type": type(result).__name__ if result else None,
-            },
-        )
-
-        return result
-
-    async def refund_payment(
-        self, args: RefundPaymentArgs
-    ) -> RefundPaymentOutcome:
-        """Refund a previously processed payment by executing an activity."""
-        logger.debug(
-            "Workflow: Calling refund_payment activity",
-            extra={"payment_id": args.payment_id, "amount": str(args.amount)},
-        )
-        raw_result = await workflow.execute_activity(
-            "sample.payment_repo.minio.refund_payment",
-            args,
-            start_to_close_timeout=self.activity_timeout,
-            retry_policy=self.activity_fail_fast_retry_policy,
-        )
-        result = RefundPaymentOutcome.model_validate(raw_result)
-        logger.debug(
-            "Workflow: refund_payment activity completed",
-            extra={
-                "payment_id": args.payment_id,
-                "result_status": result.status,
-            },
-        )
-        return result
+    pass

--- a/sample/worker.py
+++ b/sample/worker.py
@@ -139,7 +139,9 @@ async def run_worker() -> None:
         endpoint=minio_endpoint
     )
     temporal_order_request_repo = TemporalMinioOrderRequestRepository()
-    temporal_file_storage_repo = TemporalMinioFileStorageRepository()  # New Temporal activity repo
+    temporal_file_storage_repo = (
+        TemporalMinioFileStorageRepository()
+    )  # New Temporal activity repo
 
     # Create a worker that hosts workflow and activities
     # The worker automatically uses the data converter from the client.

--- a/sample/worker.py
+++ b/sample/worker.py
@@ -20,7 +20,6 @@ from sample.repos.activities import (
     TemporalMinioInventoryRepository,
     TemporalMinioOrderRequestRepository,
 )
-from util.repos.minio.file_storage import MinioFileStorageRepository
 from util.repos.temporal.minio_file_storage import (
     TemporalMinioFileStorageRepository,
 )
@@ -127,9 +126,6 @@ async def run_worker() -> None:
     # Get Minio endpoint for repositories
     logger.debug("Preparing repository configurations")
     minio_endpoint = os.environ.get("MINIO_ENDPOINT", "minio:9000")
-    minio_file_storage_repo = (
-        MinioFileStorageRepository()
-    )  # Uses its own defaults/env vars internally
 
     # Instantiate temporal repository classes (imported from sample.repos)
     logger.debug("Creating Temporal Activity repository implementations")
@@ -143,9 +139,7 @@ async def run_worker() -> None:
         endpoint=minio_endpoint
     )
     temporal_order_request_repo = TemporalMinioOrderRequestRepository()
-    temporal_file_storage_repo = TemporalMinioFileStorageRepository(
-        minio_file_storage_repo
-    )  # New Temporal activity repo
+    temporal_file_storage_repo = TemporalMinioFileStorageRepository()  # New Temporal activity repo
 
     # Create a worker that hosts workflow and activities
     # The worker automatically uses the data converter from the client.

--- a/sample/workflow.py
+++ b/sample/workflow.py
@@ -130,10 +130,10 @@ class OrderFulfillmentWorkflow:
                 },
             )
 
-            order_repo = WorkflowOrderRepositoryProxy()
-            payment_repo = WorkflowPaymentRepositoryProxy()
-            inventory_repo = WorkflowInventoryRepositoryProxy()
-            request_repo = WorkflowOrderRequestRepositoryProxy()
+            order_repo = WorkflowOrderRepositoryProxy()  # type: ignore[abstract]
+            payment_repo = WorkflowPaymentRepositoryProxy()  # type: ignore[abstract]
+            inventory_repo = WorkflowInventoryRepositoryProxy()  # type: ignore[abstract]
+            request_repo = WorkflowOrderRequestRepositoryProxy()  # type: ignore[abstract]
             file_storage_repo = WorkflowFileStorageRepositoryProxy()
 
             workflow.logger.debug(
@@ -302,9 +302,9 @@ class CancelOrderWorkflow:
         )
 
         # Create repository stubs for cancellation use case
-        order_repo = WorkflowOrderRepositoryProxy()
-        payment_repo = WorkflowPaymentRepositoryProxy()
-        inventory_repo = WorkflowInventoryRepositoryProxy()
+        order_repo = WorkflowOrderRepositoryProxy()  # type: ignore[abstract]
+        payment_repo = WorkflowPaymentRepositoryProxy()  # type: ignore[abstract]
+        inventory_repo = WorkflowInventoryRepositoryProxy()  # type: ignore[abstract]
 
         workflow.logger.debug(
             "Workflow repository stubs created for cancellation",

--- a/util/repos/temporal/decorators.py
+++ b/util/repos/temporal/decorators.py
@@ -81,23 +81,6 @@ def _discover_protocol_methods(
                         concrete_method = getattr(concrete_class, name)
                         methods_to_wrap[name] = concrete_method
 
-    # If no protocol methods found, fall back to all async methods
-    # (for backward compatibility with non-protocol base classes)
-    if not methods_to_wrap:
-        for base_class in cls_hierarchy:
-            if base_class is object:
-                continue
-
-            for name in base_class.__dict__:
-                if name in methods_to_wrap:
-                    continue
-
-                method = getattr(base_class, name)
-                if inspect.iscoroutinefunction(
-                    method
-                ) and not name.startswith("_"):
-                    methods_to_wrap[name] = method
-
     # Log final results
     final_method_names = list(methods_to_wrap.keys())
     logger.info(

--- a/util/repos/temporal/minio_file_storage.py
+++ b/util/repos/temporal/minio_file_storage.py
@@ -1,51 +1,11 @@
-import logging
-from typing import Optional
-
-from temporalio import activity
-
-from util.domain import FileMetadata, FileUploadArgs
-from util.repositories import FileStorageRepository
+from util.repos.temporal.decorators import temporal_activity_registration
 from util.repos.minio.file_storage import MinioFileStorageRepository
 
-logger = logging.getLogger(__name__)
 
-
-class TemporalMinioFileStorageRepository(FileStorageRepository):
+@temporal_activity_registration("util.file_storage.minio")
+class TemporalMinioFileStorageRepository(MinioFileStorageRepository):
     """
-    Temporal Activity implementation of FileStorageRepository.
-    Delegates calls to a concrete MinioFileStorageRepository instance.
+    Temporal activity wrapper for MinioFileStorageRepository.
+    All async methods automatically wrapped as activities.
     """
-
-    def __init__(
-        self,
-        file_storage_repo: MinioFileStorageRepository,
-    ):
-        self._file_storage_repo = file_storage_repo
-        logger.debug("Initialized TemporalMinioFileStorageRepository")
-
-    @activity.defn(name="util.file_storage.minio.upload_file")
-    async def upload_file(self, args: FileUploadArgs) -> FileMetadata:
-        """Upload a file via the underlying Minio repository."""
-        logger.info(
-            "Activity: util.file_storage.minio.upload_file called",
-            extra={"file_id": args.file_id, "filename": args.filename},
-        )
-        return await self._file_storage_repo.upload_file(args)
-
-    @activity.defn(name="util.file_storage.minio.download_file")
-    async def download_file(self, file_id: str) -> Optional[bytes]:
-        """Download a file via the underlying Minio repository."""
-        logger.info(
-            "Activity: util.file_storage.minio.download_file called",
-            extra={"file_id": file_id},
-        )
-        return await self._file_storage_repo.download_file(file_id)
-
-    @activity.defn(name="util.file_storage.minio.get_file_metadata")
-    async def get_file_metadata(self, file_id: str) -> Optional[FileMetadata]:
-        """Retrieve file metadata via the underlying Minio repository."""
-        logger.info(
-            "Activity: util.file_storage.minio.get_file_metadata called",
-            extra={"file_id": file_id},
-        )
-        return await self._file_storage_repo.get_file_metadata(file_id)
+    pass

--- a/util/repos/temporal/minio_file_storage.py
+++ b/util/repos/temporal/minio_file_storage.py
@@ -8,4 +8,5 @@ class TemporalMinioFileStorageRepository(MinioFileStorageRepository):
     Temporal activity wrapper for MinioFileStorageRepository.
     All async methods automatically wrapped as activities.
     """
+
     pass


### PR DESCRIPTION
This PR uses the new decorator created in #52 within the `sample` directory, mainly as a way to quickly test that it's working e2e (since the julee_example doesn't yet have e2e tests, but the sample does).

Deletes 400 lines of boiler-plate code for the proxies and still works :)