### PR TITLE
Fix decorator to use correct domain types.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ clean:
 # Format code with black
 format:
 	@echo "Formatting code with black..."
-	black cal/ sample/ julee_example/
+	black cal/ sample/ util/ julee_example/
 
 # Help target
 help:

--- a/util/repos/temporal/decorators.py
+++ b/util/repos/temporal/decorators.py
@@ -30,18 +30,103 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
+def _extract_concrete_type_from_base(cls: type) -> Optional[type]:
+    """
+    Extract the concrete type argument from a generic base class.
+
+    For example, if a class inherits from BaseRepository[AssemblySpec],
+    this function will return AssemblySpecification.
+
+    Args:
+        cls: Class to analyze for generic base types
+
+    Returns:
+        The concrete type if found, None otherwise
+    """
+    # Check the class hierarchy for generic base classes
+    for base in cls.__mro__:
+        # Check if this class has __orig_bases__ (generic type information)
+        if hasattr(base, "__orig_bases__"):
+            for orig_base in base.__orig_bases__:
+                origin = get_origin(orig_base)
+                if origin is not None:
+                    args = get_args(orig_base)
+                    # Look for BaseRepository[ConcreteType] pattern
+                    if (
+                        hasattr(origin, "__name__")
+                        and "Repository" in str(origin)
+                        and len(args) == 1
+                    ):
+                        concrete_type = args[0]
+                        # Make sure it's a concrete type, not another TypeVar
+                        if not isinstance(concrete_type, TypeVar):
+                            logger.debug(
+                                f"Extracted concrete type {concrete_type} "
+                                f"from {orig_base}"
+                            )
+                            return concrete_type  # type: ignore[no-any-return]
+    return None
+
+
+def _substitute_typevar_with_concrete(
+    annotation: Any, concrete_type: type
+) -> Any:
+    """
+    Substitute TypeVar instances with concrete type in type annotations.
+
+    Args:
+        annotation: Type annotation that may contain TypeVars
+        concrete_type: Concrete type to substitute for TypeVars
+
+    Returns:
+        Type annotation with TypeVars replaced by concrete type
+
+    Raises:
+        TypeError: If type reconstruction fails during substitution
+    """
+    if isinstance(annotation, TypeVar):
+        return concrete_type
+
+    origin = get_origin(annotation)
+    if origin is not None:
+        args = get_args(annotation)
+        if args:
+            # Recursively substitute in generic arguments
+            new_args = tuple(
+                _substitute_typevar_with_concrete(arg, concrete_type)
+                for arg in args
+            )
+            # Reconstruct the generic type with substituted arguments
+            try:
+                return origin[new_args]  # type: ignore
+            except TypeError as e:
+                # Fail fast - type reconstruction should work if substituting
+                raise TypeError(
+                    f"Failed to reconstruct generic type {origin} with "
+                    f"args {new_args}. "
+                    f"Original annotation: {annotation}, "
+                    f"concrete type: {concrete_type}. "
+                    f"This indicates an issue with type substitution logic."
+                ) from e
+
+    # origin is None - normal for non-generic types like str, bool, etc.
+    return annotation
+
+
 def _discover_protocol_methods(
     cls_hierarchy: tuple[type, ...],
 ) -> dict[str, Any]:
     """
-    Common function to discover protocol methods that should be wrapped.
+    Common function to discover methods that should be wrapped.
 
     This function is used by both temporal_activity_registration and
-    temporal_workflow_proxy to ensure they operate on the exact same
-    set of methods by finding async methods defined in protocol interfaces.
+    temporal_workflow_proxy to find async methods. The behavior can be
+    configured based on the decorator's needs.
 
     Args:
         cls_hierarchy: The class MRO (method resolution order)
+        protocols_only: If True, only look at Protocol classes. If False,
+                       look at all classes in the hierarchy.
 
     Returns:
         Dict mapping method names to method objects from the concrete class
@@ -49,13 +134,13 @@ def _discover_protocol_methods(
     methods_to_wrap = {}
     concrete_class = cls_hierarchy[0]  # The actual class being decorated
 
-    # Look for protocol interfaces (classes with runtime_checkable/Protocol)
+    # Look for async methods in the class hierarchy
     for base_class in cls_hierarchy:
         # Skip object base class
         if base_class is object:
             continue
 
-        # Check if this is a protocol class
+        # Check if this is a protocol class (for workflow proxies)
         has_protocol_attr = hasattr(base_class, "__protocol__")
         has_is_protocol = getattr(base_class, "_is_protocol", False)
         has_protocol_in_str = "Protocol" in str(base_class)
@@ -64,17 +149,18 @@ def _discover_protocol_methods(
             has_protocol_attr or has_is_protocol or has_protocol_in_str
         )
 
+        # Only process protocol classes for architectural compliance
         if is_protocol:
-            # Get method names defined in this protocol, but get the actual
+            # Get method names defined in this class, but get the actual
             # implementation from the concrete class
             for name in base_class.__dict__:
                 if name in methods_to_wrap:
                     continue  # Already found this method
 
-                protocol_method = getattr(base_class, name)
+                base_method = getattr(base_class, name)
                 # Only wrap async methods that don't start with underscore
                 if inspect.iscoroutinefunction(
-                    protocol_method
+                    base_method
                 ) and not name.startswith("_"):
                     # Get the concrete implementation from the actual class
                     if hasattr(concrete_class, name):
@@ -133,7 +219,7 @@ def temporal_activity_registration(
         # Track which methods we wrap for logging
         wrapped_methods = []
 
-        # Use common method discovery
+        # Use common method discovery - for activities, wrap protocol methods
         async_methods_to_wrap = _discover_protocol_methods(cls.__mro__)
 
         # Now wrap all the async methods we found
@@ -243,7 +329,7 @@ def temporal_workflow_proxy(
             maximum_interval=timedelta(seconds=1),
         )
 
-        # Use the same method discovery as temporal_activity_registration
+        # Use method discovery - for workflow proxies, wrap protocol methods
         methods_to_implement = _discover_protocol_methods(cls.__mro__)
 
         # Generate workflow proxy methods
@@ -258,6 +344,28 @@ def temporal_workflow_proxy(
             # Get method signature for type hints
             sig = inspect.signature(original_method)
             return_annotation = sig.return_annotation
+
+            # Try to extract concrete type from class inheritance
+            concrete_type = _extract_concrete_type_from_base(cls)
+
+            # Substitute TypeVars with concrete type if found
+            if concrete_type is not None:
+                return_annotation = _substitute_typevar_with_concrete(
+                    return_annotation, concrete_type
+                )
+                logger.debug(
+                    f"Substituted TypeVar in {method_name} return type: "
+                    f"{sig.return_annotation} -> {return_annotation}"
+                )
+            else:
+                # Log when we couldn't extract concrete type - might indicate
+                # a repository that doesn't follow BaseRepository[T] pattern
+                logger.debug(
+                    f"No concrete type for {cls.__name__}.{method_name}. "
+                    f"Return annotation: {sig.return_annotation}. "
+                    f"If Pydantic objects returned, ensure repo inherits "
+                    f"from BaseRepository[ConcreteType]."
+                )
 
             # Determine if return type needs Pydantic validation
             needs_validation = _needs_pydantic_validation(return_annotation)

--- a/util/repos/temporal/decorators.py
+++ b/util/repos/temporal/decorators.py
@@ -25,6 +25,8 @@ from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 from pydantic import BaseModel
 
+from julee_example.repositories.base import BaseRepository
+
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
@@ -34,8 +36,9 @@ def _extract_concrete_type_from_base(cls: type) -> Optional[type]:
     """
     Extract the concrete type argument from a generic base class.
 
-    For example, if a class inherits from BaseRepository[AssemblySpec],
-    this function will return AssemblySpecification.
+    For example, if a class inherits from
+    BaseRepository[AssemblySpecification], this function will return
+    AssemblySpecification.
 
     Args:
         cls: Class to analyze for generic base types
@@ -52,11 +55,7 @@ def _extract_concrete_type_from_base(cls: type) -> Optional[type]:
                 if origin is not None:
                     args = get_args(orig_base)
                     # Look for BaseRepository[ConcreteType] pattern
-                    if (
-                        hasattr(origin, "__name__")
-                        and "Repository" in str(origin)
-                        and len(args) == 1
-                    ):
+                    if origin is BaseRepository and len(args) == 1:
                         concrete_type = args[0]
                         # Make sure it's a concrete type, not another TypeVar
                         if not isinstance(concrete_type, TypeVar):

--- a/util/tests/test_decorators.py
+++ b/util/tests/test_decorators.py
@@ -634,6 +634,7 @@ class TestTypeSubstitution:
 
         # Patch the functions temporarily
         import util.repos.temporal.decorators as decorators_module
+
         decorators_module.get_origin = mock_get_origin  # type: ignore[assignment]
         decorators_module.get_args = mock_get_args  # type: ignore[assignment]
 
@@ -805,7 +806,7 @@ class TestEndToEndTypeSubstitution:
         assert isinstance(activity_result_dict, dict)
         with pytest.raises(AttributeError):
             # This would fail because dict doesn't have the attribute
-            getattr(activity_result_dict, 'assembly_specification_id')
+            getattr(activity_result_dict, "assembly_specification_id")
 
         # Demonstrate the solution: reconstruct Pydantic object
         reconstructed = MockAssemblySpecification.model_validate(

--- a/util/tests/test_decorators.py
+++ b/util/tests/test_decorators.py
@@ -1,21 +1,70 @@
 """
-Tests for the temporal_activity_registration decorator.
+Tests for temporal decorators.
 
-This module tests the decorator in isolation to ensure it properly wraps
-async methods as Temporal activities without depending on the existing
-repository implementations.
+This module tests the decorators in isolation to ensure they properly wrap
+async methods as Temporal activities and handle type substitution correctly.
 """
 
+import pytest
 from unittest.mock import patch
-from typing import Any, Optional
+from typing import Any, Optional, TypeVar, Protocol, runtime_checkable
+from pydantic import BaseModel
 
 from temporalio import activity
 
-from util.repos.temporal.decorators import temporal_activity_registration
+from util.repos.temporal.decorators import (
+    temporal_activity_registration,
+    temporal_workflow_proxy,
+    _extract_concrete_type_from_base,
+    _substitute_typevar_with_concrete,
+    _needs_pydantic_validation,
+)
 
 
-class MockBaseRepository:
-    """Mock base repository class for testing inheritance."""
+@runtime_checkable
+class MockBaseRepositoryProtocol(Protocol):
+    """Mock base repository protocol for testing inheritance."""
+
+    async def base_async_method(self, arg1: str) -> str:
+        """Base async method that should be wrapped."""
+        ...
+
+    def base_sync_method(self, arg1: str) -> str:
+        """Base sync method that should NOT be wrapped."""
+        ...
+
+    async def _private_async_method(self, arg1: str) -> str:
+        """Private async method that should NOT be wrapped."""
+        ...
+
+
+@runtime_checkable
+class MockRepositoryProtocol(MockBaseRepositoryProtocol, Protocol):
+    """Mock repository protocol for testing the decorator."""
+
+    async def process_payment(self, order_id: str, amount: float) -> dict:
+        """Mock payment processing method."""
+        ...
+
+    async def get_payment(self, payment_id: str) -> Optional[dict]:
+        """Mock get payment method."""
+        ...
+
+    async def refund_payment(self, payment_id: str) -> dict:
+        """Mock refund payment method."""
+        ...
+
+    def sync_method(self, value: str) -> str:
+        """Sync method that should NOT be wrapped."""
+        ...
+
+    async def _private_method(self, value: str) -> str:
+        """Private async method that should NOT be wrapped."""
+        ...
+
+
+class MockRepository(MockRepositoryProtocol):
+    """Concrete mock repository implementation for testing."""
 
     async def base_async_method(self, arg1: str) -> str:
         """Base async method that should be wrapped."""
@@ -28,10 +77,6 @@ class MockBaseRepository:
     async def _private_async_method(self, arg1: str) -> str:
         """Private async method that should NOT be wrapped."""
         return f"private_{arg1}"
-
-
-class MockRepository(MockBaseRepository):
-    """Mock repository class for testing the decorator."""
 
     async def process_payment(self, order_id: str, amount: float) -> dict:
         """Mock payment processing method."""
@@ -245,18 +290,46 @@ def test_activity_names_with_different_prefixes() -> None:
 def test_decorator_handles_inheritance_correctly() -> None:
     """Test that the decorator properly handles method resolution order."""
 
-    class ChildRepository(MockRepository):
+    @runtime_checkable
+    class ChildRepositoryProtocol(MockRepositoryProtocol, Protocol):
         async def child_method(self, value: str) -> str:
             """Child-specific method."""
-            return f"child_{value}"
+            ...
+
+    class ChildRepository(ChildRepositoryProtocol):
+        async def base_async_method(self, arg1: str) -> str:
+            return f"base_result_{arg1}"
+
+        def base_sync_method(self, arg1: str) -> str:
+            return f"base_sync_{arg1}"
+
+        async def _private_async_method(self, arg1: str) -> str:
+            return f"private_{arg1}"
 
         async def process_payment(self, order_id: str, amount: float) -> dict:
-            """Override parent method."""
             return {
-                "status": "child_success",
+                "status": "success",
                 "order_id": order_id,
                 "amount": amount,
             }
+
+        async def get_payment(self, payment_id: str) -> Optional[dict]:
+            if payment_id == "not_found":
+                return None
+            return {"payment_id": payment_id, "status": "completed"}
+
+        async def refund_payment(self, payment_id: str) -> dict:
+            return {"status": "refunded", "payment_id": payment_id}
+
+        def sync_method(self, value: str) -> str:
+            return f"sync_{value}"
+
+        async def _private_method(self, value: str) -> str:
+            return f"private_{value}"
+
+        async def child_method(self, value: str) -> str:
+            """Child-specific method."""
+            return f"child_{value}"
 
     @temporal_activity_registration("test.child")
     class DecoratedChildRepository(ChildRepository):
@@ -285,18 +358,27 @@ def test_decorator_logs_wrapped_methods() -> None:
 
         # Check that debug logs were called for each method
         mock_logger.debug.assert_called()
-        mock_logger.info.assert_called_once()
 
-        # Check that the info log contains the expected information
-        info_call = mock_logger.info.call_args
-        assert "Temporal repository decorator applied" in info_call[0][0]
-        assert "DecoratedRepository" in info_call[0][0]
+        # Should have two info calls: method discovery and decorator app
+        assert mock_logger.info.call_count == 2
+
+        # Check that the final info log contains the expected information
+        final_info_call = mock_logger.info.call_args_list[-1]
+        assert (
+            "Temporal activity registration decorator applied"
+            in final_info_call[0][0]
+        )
+        assert "DecoratedRepository" in final_info_call[0][0]
 
 
 def test_empty_class_decorator() -> None:
     """Test decorator behavior with a class that has no async methods."""
 
-    class EmptyRepository:
+    @runtime_checkable
+    class EmptyRepositoryProtocol(Protocol):
+        def sync_only(self, value: str) -> str: ...
+
+    class EmptyRepository(EmptyRepositoryProtocol):
         def sync_only(self, value: str) -> str:
             return f"sync_{value}"
 
@@ -322,7 +404,7 @@ def test_decorator_type_preservation() -> None:
     # Check that isinstance still works
     assert isinstance(repo, DecoratedRepository)
     assert isinstance(repo, MockRepository)
-    assert isinstance(repo, MockBaseRepository)
+    assert isinstance(repo, MockBaseRepositoryProtocol)
 
 
 def test_multiple_decorations() -> None:
@@ -343,3 +425,395 @@ def test_multiple_decorations() -> None:
     assert "__temporal_activity_definition" in dir(
         SecondDecoration.process_payment
     )
+
+
+# Test domain models for type substitution tests
+class MockAssemblySpecification(BaseModel):
+    """Mock domain model for type substitution tests."""
+
+    assembly_specification_id: str
+    name: str
+    status: str = "active"
+
+
+class MockDocument(BaseModel):
+    """Another mock domain model."""
+
+    document_id: str
+    title: str
+    content: str
+
+
+# Test repository protocols
+T = TypeVar("T", bound=BaseModel)
+
+
+@runtime_checkable
+class BaseRepository(Protocol[T]):
+    """Generic base repository protocol for testing."""
+
+    async def get(self, entity_id: str) -> Optional[T]: ...
+
+    async def save(self, entity: T) -> None: ...
+
+    async def generate_id(self) -> str: ...
+
+
+@runtime_checkable
+class MockAssemblySpecificationRepository(
+    BaseRepository[MockAssemblySpecification], Protocol
+):
+    """Mock repository inheriting from BaseRepository with concrete type."""
+
+    pass
+
+
+@runtime_checkable
+class MockDocumentRepository(BaseRepository[MockDocument], Protocol):
+    """Another mock repository with different concrete type."""
+
+    pass
+
+
+@runtime_checkable
+class NonGenericRepository(Protocol):
+    """Repository that doesn't follow BaseRepository[T] pattern."""
+
+    async def get(self, id: str) -> Optional[MockDocument]: ...
+
+
+class TestTypeExtraction:
+    """Tests for _extract_concrete_type_from_base function."""
+
+    def test_extracts_concrete_type_from_direct_inheritance(self) -> None:
+        """Test extracting type from direct BaseRepository inheritance."""
+        concrete_type = _extract_concrete_type_from_base(
+            MockAssemblySpecificationRepository
+        )
+        assert concrete_type == MockAssemblySpecification
+
+    def test_extracts_different_concrete_types(self) -> None:
+        """Test different repositories extract their concrete types."""
+        assembly_type = _extract_concrete_type_from_base(
+            MockAssemblySpecificationRepository
+        )
+        document_type = _extract_concrete_type_from_base(
+            MockDocumentRepository
+        )
+
+        assert assembly_type == MockAssemblySpecification
+        assert document_type == MockDocument
+        assert assembly_type != document_type
+
+    def test_extracts_from_proxy_class_inheritance(self) -> None:
+        """Test extracting concrete type from workflow proxy classes."""
+
+        class TestWorkflowProxy(MockAssemblySpecificationRepository):
+            pass
+
+        concrete_type = _extract_concrete_type_from_base(TestWorkflowProxy)
+        assert concrete_type == MockAssemblySpecification
+
+    def test_returns_none_for_non_generic_repository(self) -> None:
+        """Test that non-generic repositories return None."""
+        concrete_type = _extract_concrete_type_from_base(NonGenericRepository)
+        assert concrete_type is None
+
+    def test_returns_none_for_object_class(self) -> None:
+        """Test that base object class returns None."""
+        concrete_type = _extract_concrete_type_from_base(object)
+        assert concrete_type is None
+
+
+class TestTypeSubstitution:
+    """Tests for _substitute_typevar_with_concrete function."""
+
+    def test_substitutes_direct_typevar(self) -> None:
+        """Test direct TypeVar substitution."""
+        result = _substitute_typevar_with_concrete(
+            T, MockAssemblySpecification
+        )
+        assert result == MockAssemblySpecification
+
+    def test_substitutes_optional_typevar(self) -> None:
+        """Test Optional[TypeVar] substitution."""
+        optional_t = Optional[T]
+        result = _substitute_typevar_with_concrete(
+            optional_t, MockAssemblySpecification
+        )
+
+        # Should be Optional[MockAssemblySpecification]
+        from typing import get_origin, get_args
+
+        origin = get_origin(result)
+        args = get_args(result)
+        assert origin is not None
+        assert MockAssemblySpecification in args
+        assert type(None) in args
+
+    def test_substitutes_nested_generics(self) -> None:
+        """Test substitution in nested generic types."""
+        from typing import List
+
+        nested_generic = List[Optional[T]]
+        result = _substitute_typevar_with_concrete(
+            nested_generic, MockDocument
+        )
+
+        # Should be List[Optional[MockDocument]]
+        from typing import get_origin, get_args
+
+        outer_origin = get_origin(result)
+        outer_args = get_args(result)
+        assert outer_origin is list
+        assert len(outer_args) == 1
+
+        inner_type = outer_args[0]
+        inner_args = get_args(inner_type)
+        assert MockDocument in inner_args
+        assert type(None) in inner_args
+
+    def test_returns_non_generic_types_unchanged(self) -> None:
+        """Test that non-generic types are returned unchanged."""
+        result_str = _substitute_typevar_with_concrete(
+            str, MockAssemblySpecification
+        )
+        result_int = _substitute_typevar_with_concrete(
+            int, MockAssemblySpecification
+        )
+        result_concrete = _substitute_typevar_with_concrete(
+            MockDocument, MockAssemblySpecification
+        )
+
+        assert result_str is str
+        assert result_int is int
+        assert result_concrete == MockDocument
+
+    def test_handles_none_annotation(self) -> None:
+        """Test handling of None annotations."""
+        result = _substitute_typevar_with_concrete(
+            None, MockAssemblySpecification
+        )
+        assert result is None
+
+    def test_handles_signature_empty(self) -> None:
+        """Test handling of inspect.Signature.empty."""
+        import inspect
+
+        result = _substitute_typevar_with_concrete(
+            inspect.Signature.empty, MockAssemblySpecification
+        )
+        assert result == inspect.Signature.empty
+
+    def test_fails_fast_on_reconstruction_error(self) -> None:
+        """Test that reconstruction errors raise informative exceptions."""
+
+        # Create a mock type that will fail reconstruction
+        class FailingOrigin:
+            def __getitem__(self, item: Any) -> Any:
+                raise TypeError("Mock reconstruction failure")
+
+            def __str__(self) -> str:
+                return "FailingOrigin"
+
+        # Mock get_origin and get_args to return our failing type
+        from typing import get_origin, get_args
+
+        original_get_origin = get_origin
+        original_get_args = get_args
+
+        def mock_get_origin(annotation: Any) -> Any:
+            if annotation == "FAILING_TYPE":
+                return FailingOrigin()
+            return original_get_origin(annotation)
+
+        def mock_get_args(annotation: Any) -> tuple[Any, ...]:
+            if annotation == "FAILING_TYPE":
+                return (T,)
+            return original_get_args(annotation)
+
+        # Patch the functions temporarily
+        import util.repos.temporal.decorators as decorators_module
+        decorators_module.get_origin = mock_get_origin  # type: ignore[assignment]
+        decorators_module.get_args = mock_get_args  # type: ignore[assignment]
+
+        try:
+            with pytest.raises(TypeError) as exc_info:
+                _substitute_typevar_with_concrete(
+                    "FAILING_TYPE", MockAssemblySpecification
+                )
+
+            error_message = str(exc_info.value)
+            assert "Failed to reconstruct generic type" in error_message
+            assert "FailingOrigin" in error_message
+            assert "FAILING_TYPE" in error_message
+            assert "MockAssemblySpecification" in error_message
+        finally:
+            # Restore original functions
+            decorators_module.get_origin = original_get_origin
+            decorators_module.get_args = original_get_args
+
+
+class TestPydanticValidationDetection:
+    """Tests for _needs_pydantic_validation function."""
+
+    def test_detects_pydantic_model_types(self) -> None:
+        """Test detection of Pydantic model types."""
+        assert _needs_pydantic_validation(MockAssemblySpecification)
+        assert _needs_pydantic_validation(MockDocument)
+
+    def test_detects_optional_pydantic_types(self) -> None:
+        """Test detection of Optional[PydanticModel] types."""
+        assert _needs_pydantic_validation(Optional[MockAssemblySpecification])
+        assert _needs_pydantic_validation(Optional[MockDocument])
+
+    def test_rejects_non_pydantic_types(self) -> None:
+        """Test that non-Pydantic types are not flagged for validation."""
+        assert not _needs_pydantic_validation(str)
+        assert not _needs_pydantic_validation(int)
+        assert not _needs_pydantic_validation(dict)
+        assert not _needs_pydantic_validation(Optional[str])
+
+    def test_rejects_typevar_types(self) -> None:
+        """Test TypeVar types aren't flagged for validation (the bug)."""
+        assert not _needs_pydantic_validation(T)
+        assert not _needs_pydantic_validation(Optional[T])
+
+    def test_handles_none_and_empty(self) -> None:
+        """Test handling of None and Signature.empty."""
+        import inspect
+
+        assert not _needs_pydantic_validation(None)
+        assert not _needs_pydantic_validation(inspect.Signature.empty)
+
+
+class TestWorkflowProxyIntegration:
+    """Integration tests for temporal_workflow_proxy with substitution."""
+
+    def test_extracts_type_from_proxy_class(self) -> None:
+        """Test decorator extracts concrete types from proxy classes."""
+
+        @temporal_workflow_proxy(
+            activity_base="test.assembly_spec_repo.minio",
+            default_timeout_seconds=30,
+        )
+        class TestWorkflowAssemblySpecificationRepositoryProxy(
+            MockAssemblySpecificationRepository
+        ):
+            pass
+
+        # Verify type extraction works
+        concrete_type = _extract_concrete_type_from_base(
+            TestWorkflowAssemblySpecificationRepositoryProxy
+        )
+        assert concrete_type == MockAssemblySpecification
+
+    def test_creates_proxy_methods(self) -> None:
+        """Test that the decorator creates expected proxy methods."""
+
+        @temporal_workflow_proxy(
+            activity_base="test.document_repo.minio",
+            default_timeout_seconds=30,
+        )
+        class TestWorkflowDocumentRepositoryProxy(MockDocumentRepository):
+            pass
+
+        proxy = TestWorkflowDocumentRepositoryProxy()  # type: ignore[abstract]
+
+        # Check that methods exist
+        assert hasattr(proxy, "get")
+        assert hasattr(proxy, "save")
+        assert hasattr(proxy, "generate_id")
+
+        # Check instance attributes
+        assert hasattr(proxy, "activity_timeout")
+        assert hasattr(proxy, "activity_fail_fast_retry_policy")
+
+    def test_different_repositories_get_different_types(self) -> None:
+        """Test that different repositories extract their respective types."""
+
+        @temporal_workflow_proxy(
+            activity_base="test.assembly_spec_repo.minio",
+            default_timeout_seconds=30,
+        )
+        class ProxyA(MockAssemblySpecificationRepository):
+            pass
+
+        @temporal_workflow_proxy(
+            activity_base="test.document_repo.minio",
+            default_timeout_seconds=30,
+        )
+        class ProxyB(MockDocumentRepository):
+            pass
+
+        type_a = _extract_concrete_type_from_base(ProxyA)
+        type_b = _extract_concrete_type_from_base(ProxyB)
+
+        assert type_a == MockAssemblySpecification
+        assert type_b == MockDocument
+        assert type_a != type_b
+
+    def test_handles_non_generic_repository_gracefully(self) -> None:
+        """Test that non-generic repositories are handled gracefully."""
+
+        @temporal_workflow_proxy(
+            activity_base="test.non_generic_repo.minio",
+            default_timeout_seconds=30,
+        )
+        class TestNonGenericProxy(NonGenericRepository):
+            pass
+
+        # Should not raise an error
+        proxy = TestNonGenericProxy()  # type: ignore[abstract]
+        assert hasattr(proxy, "get")
+
+        # Should return None for concrete type (logged but not errored)
+        concrete_type = _extract_concrete_type_from_base(TestNonGenericProxy)
+        assert concrete_type is None
+
+
+class TestEndToEndTypeSubstitution:
+    """End-to-end tests demonstrating the complete type substitution fix."""
+
+    def test_type_substitution_enables_pydantic_validation(self) -> None:
+        """Test type substitution enables Pydantic validation."""
+        # Simulate the problematic method signature: Optional[~T]
+        original_annotation = Optional[T]
+
+        # Before fix: TypeVar prevents validation
+        assert not _needs_pydantic_validation(original_annotation)
+
+        # After substitution: Concrete type enables validation
+        substituted_annotation = _substitute_typevar_with_concrete(
+            original_annotation, MockAssemblySpecification
+        )
+        assert _needs_pydantic_validation(substituted_annotation)
+
+    def test_demonstrates_original_problem_and_solution(self) -> None:
+        """Test dict vs Pydantic object problem and solution."""
+        # Create test data
+        test_spec = MockAssemblySpecification(
+            assembly_specification_id="test-123",
+            name="Test Spec",
+            status="active",
+        )
+
+        # Convert to dict (simulates what Temporal activity returns)
+        activity_result_dict = test_spec.model_dump(mode="json")
+
+        # Demonstrate the problem: dict doesn't have Pydantic attributes
+        assert isinstance(activity_result_dict, dict)
+        with pytest.raises(AttributeError):
+            # This would fail because dict doesn't have the attribute
+            getattr(activity_result_dict, 'assembly_specification_id')
+
+        # Demonstrate the solution: reconstruct Pydantic object
+        reconstructed = MockAssemblySpecification.model_validate(
+            activity_result_dict
+        )
+        assert isinstance(reconstructed, MockAssemblySpecification)
+        assert (
+            reconstructed.assembly_specification_id == "test-123"
+        )  # This works
+        assert reconstructed.name == "Test Spec"
+        assert reconstructed.status == "active"


### PR DESCRIPTION
I was finding that temporal workflows were failing because they were being passed python dicts, rather than Pydantic domain models, which caused `AttributeError`'s when trying to access Pydantic model attributes using dot notation.

It took a while to debug, but it came down to the  `@temporal_workflow_proxy` decorator in `util/repos/temporal/decorators.py` being applied to the generic `class BaseRepository(Protocol[T]):`  model that I created since all repositories had the same methods.

This left the decorator unable to know the actual return type (it just knew it as the generic `T`), and so when temporal's pydantic plugin tried to determine the type to convert the json to a pydatic model, it couldn't and so was just returning the json.

I initially fixed this by updating the decorator signature to include the domain type, but then realised that we already have that information in the inheritance chain (eg. a `WorkflowAssemblySpecificationRepository` inherits from `BaseRepository(Protocol[AssemblySpecification])`, so this PR updates the decorator to pull out the `AssemblySpecification` and update the return types for the decorated methods.