### PR TITLE
Enable saving a Document with content_string for small payloads.

### DIFF
--- a/julee_example/domain/document/document.py
+++ b/julee_example/domain/document/document.py
@@ -89,7 +89,15 @@ class Document(BaseModel):
 
     # Additional data and content stream
     additional_metadata: Dict[str, Any] = Field(default_factory=dict)
-    content: ContentStream = Field(exclude=True)
+    content: Optional[ContentStream] = Field(default=None, exclude=True)
+    content_string: Optional[str] = Field(
+        default=None,
+        description="Small content as string (few KB max). Use for "
+        "workflow-generated content to avoid ContentStream serialization "
+        "issues. For larger content, ensure calling from concrete "
+        "implementations (ie. outside workflows and use-cases) and use "
+        "content field instead.",
+    )
 
     @field_validator("document_id")
     @classmethod

--- a/julee_example/domain/document/document.py
+++ b/julee_example/domain/document/document.py
@@ -127,3 +127,24 @@ class Document(BaseModel):
         if not v or not v.strip():
             raise ValueError("Content multihash cannot be empty")
         return v.strip()
+
+    @field_validator("content_string")
+    @classmethod
+    def validate_content_exclusivity(
+        cls, v: Optional[str], info: Any
+    ) -> Optional[str]:
+        """Ensure document has either content or content_string, not both."""
+        has_content = info.data.get("content") is not None
+        has_content_string = v is not None
+
+        if has_content and has_content_string:
+            raise ValueError(
+                "Document cannot have both content and content_string. "
+                "Provide only one."
+            )
+        elif not has_content and not has_content_string:
+            raise ValueError(
+                "Document must have either content or content_string. "
+                "Provide one."
+            )
+        return v

--- a/julee_example/repositories/memory/document.py
+++ b/julee_example/repositories/memory/document.py
@@ -110,7 +110,12 @@ class MemoryDocumentRepository(
                 },
             )
 
-        self.save_entity(document, "document_id")
+        # Create a copy without content_string (content saved
+        # in separate content-addressable storage)
+        document_for_storage = document.model_copy(
+            update={"content_string": None}
+        )
+        self.save_entity(document_for_storage, "document_id")
 
     async def generate_id(self) -> str:
         """Generate a unique document identifier.

--- a/julee_example/repositories/memory/document.py
+++ b/julee_example/repositories/memory/document.py
@@ -67,23 +67,8 @@ class MemoryDocumentRepository(
         Raises:
             ValueError: If document has no content or content_string
         """
-        # Fail fast if both are provided or neither are provided
-        has_content = document.content is not None
-        has_content_string = document.content_string is not None
-
-        if has_content and has_content_string:
-            raise ValueError(
-                f"Document {document.document_id} has both content and "
-                "content_string. Provide only one."
-            )
-        elif not has_content and not has_content_string:
-            raise ValueError(
-                f"Document {document.document_id} has no content or "
-                "content_string. Provide one."
-            )
-
         # Handle content_string conversion (only if no content provided)
-        if has_content_string:
+        if document.content_string is not None:
             # Convert content_string to ContentStream
             assert document.content_string is not None  # For MyPy
             content_bytes = document.content_string.encode("utf-8")

--- a/julee_example/repositories/memory/document.py
+++ b/julee_example/repositories/memory/document.py
@@ -67,19 +67,25 @@ class MemoryDocumentRepository(
         Raises:
             ValueError: If document has no content or content_string
         """
-        # Fail fast if both content and content_string are provided
-        if (
-            document.content is not None
-            and document.content_string is not None
-        ):
+        # Fail fast if both are provided or neither are provided
+        has_content = document.content is not None
+        has_content_string = document.content_string is not None
+
+        if has_content and has_content_string:
             raise ValueError(
                 f"Document {document.document_id} has both content and "
                 "content_string. Provide only one."
             )
+        elif not has_content and not has_content_string:
+            raise ValueError(
+                f"Document {document.document_id} has no content or "
+                "content_string. Provide one."
+            )
 
         # Handle content_string conversion (only if no content provided)
-        if document.content is None and document.content_string is not None:
+        if has_content_string:
             # Convert content_string to ContentStream
+            assert document.content_string is not None  # For MyPy
             content_bytes = document.content_string.encode("utf-8")
             content_stream = ContentStream(io.BytesIO(content_bytes))
 
@@ -102,11 +108,6 @@ class MemoryDocumentRepository(
                     "content_hash": content_hash,
                     "content_length": len(content_bytes),
                 },
-            )
-        elif document.content is None and document.content_string is None:
-            raise ValueError(
-                f"Document {document.document_id} has no content or "
-                "content_string"
             )
 
         self.save_entity(document, "document_id")

--- a/julee_example/repositories/memory/document.py
+++ b/julee_example/repositories/memory/document.py
@@ -11,10 +11,12 @@ ideal for testing scenarios where external dependencies should be avoided.
 All operations are still async to maintain interface compatibility.
 """
 
+import hashlib
+import io
 import logging
 from typing import Optional, Dict, Any
 
-from julee_example.domain import Document
+from julee_example.domain import Document, ContentStream
 from julee_example.repositories.document import DocumentRepository
 from .base import MemoryRepositoryMixin
 
@@ -56,9 +58,57 @@ class MemoryDocumentRepository(
     async def save(self, document: Document) -> None:
         """Save a document with its content and metadata.
 
+        If the document has content_string, it will be converted to a
+        ContentStream and the content hash will be calculated automatically.
+
         Args:
             document: Document object to save
+
+        Raises:
+            ValueError: If document has no content or content_string
         """
+        # Fail fast if both content and content_string are provided
+        if (
+            document.content is not None
+            and document.content_string is not None
+        ):
+            raise ValueError(
+                f"Document {document.document_id} has both content and "
+                "content_string. Provide only one."
+            )
+
+        # Handle content_string conversion (only if no content provided)
+        if document.content is None and document.content_string is not None:
+            # Convert content_string to ContentStream
+            content_bytes = document.content_string.encode("utf-8")
+            content_stream = ContentStream(io.BytesIO(content_bytes))
+
+            # Calculate content hash
+            content_hash = hashlib.sha256(content_bytes).hexdigest()
+
+            # Create new document with ContentStream and calculated hash
+            document = document.model_copy(
+                update={
+                    "content": content_stream,
+                    "content_multihash": content_hash,
+                    "size_bytes": len(content_bytes),
+                }
+            )
+
+            self.logger.debug(
+                "Converted content_string to ContentStream for document save",
+                extra={
+                    "document_id": document.document_id,
+                    "content_hash": content_hash,
+                    "content_length": len(content_bytes),
+                },
+            )
+        elif document.content is None and document.content_string is None:
+            raise ValueError(
+                f"Document {document.document_id} has no content or "
+                "content_string"
+            )
+
         self.save_entity(document, "document_id")
 
     async def generate_id(self) -> str:

--- a/julee_example/repositories/memory/tests/test_document.py
+++ b/julee_example/repositories/memory/tests/test_document.py
@@ -1,0 +1,224 @@
+"""
+Unit tests for MemoryDocumentRepository.
+
+These tests verify the memory implementation logic without requiring external
+dependencies. They follow the Clean Architecture testing patterns and verify
+idempotency, error handling, and content operations including content_string.
+"""
+
+import io
+import pytest
+from julee_example.repositories.memory.document import (
+    MemoryDocumentRepository,
+)
+from julee_example.domain import Document, DocumentStatus, ContentStream
+
+
+@pytest.fixture
+def repository() -> MemoryDocumentRepository:
+    """Provide a repository instance for testing."""
+    return MemoryDocumentRepository()
+
+
+@pytest.fixture
+def sample_content() -> ContentStream:
+    """Sample content for testing."""
+    content_bytes = b"This is test content for document storage"
+    return ContentStream(io.BytesIO(content_bytes))
+
+
+@pytest.fixture
+def sample_document(sample_content: ContentStream) -> Document:
+    """Sample document for testing."""
+    return Document(
+        document_id="test-doc-123",
+        original_filename="test.txt",
+        content_type="text/plain",
+        size_bytes=41,
+        content_multihash="test_hash_placeholder",
+        status=DocumentStatus.CAPTURED,
+        content=sample_content,
+    )
+
+
+class TestMemoryDocumentRepositoryContentString:
+    """Test content_string functionality."""
+
+    async def test_save_document_with_content_string(
+        self, repository: MemoryDocumentRepository
+    ) -> None:
+        """Test saving document with content_string (small content)."""
+        content = '{"assembled": "document", "data": "test"}'
+
+        # Create document with content_string
+        document = Document(
+            document_id="test-doc-content-string",
+            original_filename="assembled.json",
+            content_type="application/json",
+            size_bytes=100,  # Will be updated automatically
+            content_multihash="placeholder",  # Will be updated automatically
+            status=DocumentStatus.CAPTURED,
+            content_string=content,
+        )
+
+        # Act - save should convert content_string to ContentStream
+        await repository.save(document)
+
+        # Assert document was saved successfully
+        retrieved = await repository.get(document.document_id)
+        assert retrieved is not None
+        assert (
+            retrieved.content_multihash != "placeholder"
+        )  # Hash was calculated
+        assert retrieved.size_bytes == len(content.encode("utf-8"))
+
+        # Verify content can be read
+        assert retrieved.content is not None
+        retrieved_content = retrieved.content.read().decode("utf-8")
+        assert retrieved_content == content
+
+    async def test_save_document_with_content_string_unicode(
+        self, repository: MemoryDocumentRepository
+    ) -> None:
+        """Test saving document with unicode content_string."""
+        content = '{"title": "测试文档", "emoji": "🚀", "content": "éñ"}'
+
+        document = Document(
+            document_id="test-doc-unicode",
+            original_filename="unicode.json",
+            content_type="application/json",
+            size_bytes=100,
+            content_multihash="placeholder",
+            status=DocumentStatus.CAPTURED,
+            content_string=content,
+        )
+
+        await repository.save(document)
+        retrieved = await repository.get(document.document_id)
+
+        assert retrieved is not None
+        assert retrieved.content is not None
+        retrieved_content = retrieved.content.read().decode("utf-8")
+        assert retrieved_content == content
+
+    # Note: Empty content test removed because domain model requires
+    # size_bytes > 0
+
+    async def test_save_document_with_both_content_and_content_string(
+        self,
+        repository: MemoryDocumentRepository,
+        sample_content: ContentStream,
+    ) -> None:
+        """Test that both content and content_string raises error."""
+        content_string = '{"type": "string"}'
+
+        document = Document(
+            document_id="test-doc-both",
+            original_filename="both.json",
+            content_type="application/json",
+            size_bytes=100,
+            content_multihash="test_hash",
+            status=DocumentStatus.CAPTURED,
+            content=sample_content,
+            content_string=content_string,
+        )
+
+        with pytest.raises(
+            ValueError, match="has both content and content_string"
+        ):
+            await repository.save(document)
+
+    async def test_save_document_without_content_or_content_string(
+        self, repository: MemoryDocumentRepository
+    ) -> None:
+        """Test that saving without content or content_string raises error."""
+        document = Document(
+            document_id="test-doc-no-content",
+            original_filename="empty.json",
+            content_type="application/json",
+            size_bytes=100,
+            content_multihash="test_hash",
+            status=DocumentStatus.CAPTURED,
+            content=None,
+            content_string=None,
+        )
+
+        with pytest.raises(
+            ValueError, match="has no content or content_string"
+        ):
+            await repository.save(document)
+
+
+class TestMemoryDocumentRepositoryBasicOperations:
+    """Test basic repository operations."""
+
+    async def test_save_and_get_document_with_content_stream(
+        self, repository: MemoryDocumentRepository, sample_document: Document
+    ) -> None:
+        """Test basic save and retrieve operations with ContentStream."""
+        # Act
+        await repository.save(sample_document)
+        retrieved = await repository.get(sample_document.document_id)
+
+        # Assert
+        assert retrieved is not None
+        assert retrieved.document_id == sample_document.document_id
+        assert (
+            retrieved.original_filename == sample_document.original_filename
+        )
+
+    async def test_get_nonexistent_document(
+        self, repository: MemoryDocumentRepository
+    ) -> None:
+        """Test retrieving a document that doesn't exist."""
+        result = await repository.get("nonexistent-123")
+        assert result is None
+
+    async def test_generate_id(
+        self, repository: MemoryDocumentRepository
+    ) -> None:
+        """Test that generate_id returns a unique string."""
+        doc_id_1 = await repository.generate_id()
+        doc_id_2 = await repository.generate_id()
+
+        assert isinstance(doc_id_1, str)
+        assert isinstance(doc_id_2, str)
+        assert doc_id_1 != doc_id_2
+        assert len(doc_id_1) > 0
+        assert len(doc_id_2) > 0
+
+
+class TestMemoryDocumentRepositoryErrorHandling:
+    """Test error handling scenarios."""
+
+    async def test_save_handles_empty_document_id(
+        self, repository: MemoryDocumentRepository
+    ) -> None:
+        """Test error handling for empty document ID."""
+        with pytest.raises(ValueError, match="Document ID cannot be empty"):
+            Document(
+                document_id="",
+                original_filename="test.txt",
+                content_type="text/plain",
+                size_bytes=100,
+                content_multihash="test_hash",
+                status=DocumentStatus.CAPTURED,
+                content_string="test content",
+            )
+
+    async def test_save_handles_empty_filename(
+        self, repository: MemoryDocumentRepository
+    ) -> None:
+        """Test error handling for empty filename."""
+        with pytest.raises(
+            ValueError, match="Original filename cannot be empty"
+        ):
+            Document(
+                document_id="test-123",
+                original_filename="",
+                content_type="text/plain",
+                size_bytes=100,
+                content_multihash="test_hash",
+                status=DocumentStatus.CAPTURED,
+                content_string="test content",
+            )

--- a/julee_example/repositories/memory/tests/test_document.py
+++ b/julee_example/repositories/memory/tests/test_document.py
@@ -104,50 +104,6 @@ class TestMemoryDocumentRepositoryContentString:
     # Note: Empty content test removed because domain model requires
     # size_bytes > 0
 
-    async def test_save_document_with_both_content_and_content_string(
-        self,
-        repository: MemoryDocumentRepository,
-        sample_content: ContentStream,
-    ) -> None:
-        """Test that both content and content_string raises error."""
-        content_string = '{"type": "string"}'
-
-        document = Document(
-            document_id="test-doc-both",
-            original_filename="both.json",
-            content_type="application/json",
-            size_bytes=100,
-            content_multihash="test_hash",
-            status=DocumentStatus.CAPTURED,
-            content=sample_content,
-            content_string=content_string,
-        )
-
-        with pytest.raises(
-            ValueError, match="has both content and content_string"
-        ):
-            await repository.save(document)
-
-    async def test_save_document_without_content_or_content_string(
-        self, repository: MemoryDocumentRepository
-    ) -> None:
-        """Test that saving without content or content_string raises error."""
-        document = Document(
-            document_id="test-doc-no-content",
-            original_filename="empty.json",
-            content_type="application/json",
-            size_bytes=100,
-            content_multihash="test_hash",
-            status=DocumentStatus.CAPTURED,
-            content=None,
-            content_string=None,
-        )
-
-        with pytest.raises(
-            ValueError, match="has no content or content_string"
-        ):
-            await repository.save(document)
-
     async def test_save_excludes_content_string_from_storage(
         self, repository: MemoryDocumentRepository
     ) -> None:

--- a/julee_example/repositories/minio/document.py
+++ b/julee_example/repositories/minio/document.py
@@ -337,8 +337,10 @@ class MinioDocumentRepository(DocumentRepository, MinioRepositoryMixin):
         """Store document metadata to Minio with idempotency check."""
         object_name = document.document_id
 
-        # Serialize metadata (content stream is excluded from serialization)
-        metadata_json = document.model_dump_json().encode("utf-8")
+        # Serialize metadata (content stream and content_string excluded)
+        metadata_json = document.model_dump_json(
+            exclude={"content", "content_string"}
+        ).encode("utf-8")
 
         try:
             # Check if metadata already exists and is identical (idempotency)

--- a/julee_example/repositories/minio/document.py
+++ b/julee_example/repositories/minio/document.py
@@ -162,23 +162,8 @@ class MinioDocumentRepository(DocumentRepository, MinioRepositoryMixin):
         self.update_timestamps(document)
 
         try:
-            # Fail fast if both are provided or neither are provided
-            has_content = document.content is not None
-            has_content_string = document.content_string is not None
-
-            if has_content and has_content_string:
-                raise ValueError(
-                    f"Document {document.document_id} has both content and "
-                    "content_string. Provide only one."
-                )
-            elif not has_content and not has_content_string:
-                raise ValueError(
-                    f"Document {document.document_id} has no content or "
-                    "content_string. Provide one."
-                )
-
             # Handle content_string conversion (only if no content provided)
-            if has_content_string:
+            if document.content_string is not None:
                 # Convert content_string to ContentStream
                 assert document.content_string is not None  # For MyPy
                 content_bytes = document.content_string.encode("utf-8")

--- a/julee_example/repositories/minio/tests/test_document.py
+++ b/julee_example/repositories/minio/tests/test_document.py
@@ -506,50 +506,6 @@ class TestMinioDocumentRepositoryContentString:
     # Note: Empty content test removed because domain model requires
     # size_bytes > 0
 
-    async def test_save_document_with_both_content_and_content_string(
-        self,
-        repository: MinioDocumentRepository,
-        sample_content: ContentStream,
-    ) -> None:
-        """Test that both content and content_string raises error."""
-        content_string = '{"type": "string"}'
-
-        document = Document(
-            document_id="test-doc-both",
-            original_filename="both.json",
-            content_type="application/json",
-            size_bytes=100,
-            content_multihash="test_hash",
-            status=DocumentStatus.CAPTURED,
-            content=sample_content,
-            content_string=content_string,
-        )
-
-        with pytest.raises(
-            ValueError, match="has both content and content_string"
-        ):
-            await repository.save(document)
-
-    async def test_save_document_without_content_or_content_string(
-        self, repository: MinioDocumentRepository
-    ) -> None:
-        """Test that saving without content or content_string raises error."""
-        document = Document(
-            document_id="test-doc-no-content",
-            original_filename="empty.json",
-            content_type="application/json",
-            size_bytes=100,
-            content_multihash="test_hash",
-            status=DocumentStatus.CAPTURED,
-            content=None,
-            content_string=None,
-        )
-
-        with pytest.raises(
-            ValueError, match="has no content or content_string"
-        ):
-            await repository.save(document)
-
     async def test_save_excludes_content_string_from_metadata(
         self,
         repository: MinioDocumentRepository,

--- a/julee_example/services/knowledge_service/anthropic/knowledge_service.py
+++ b/julee_example/services/knowledge_service/anthropic/knowledge_service.py
@@ -97,6 +97,7 @@ class AnthropicKnowledgeService(KnowledgeService):
         try:
 
             # Reset stream position and pass stream to Anthropic
+            assert document.content is not None
             document.content.seek(0)
 
             # Upload file using Anthropic beta Files API

--- a/julee_example/use_cases/tests/test_extract_assemble_data.py
+++ b/julee_example/use_cases/tests/test_extract_assemble_data.py
@@ -305,6 +305,7 @@ class TestExtractAssembleDataUseCase:
         assert assembled_doc.status == DocumentStatus.ASSEMBLED
 
         # Check assembled content
+        assert assembled_doc.content is not None
         assembled_doc.content.seek(0)
         content = assembled_doc.content.read().decode("utf-8")
         assembled_data = json.loads(content)

--- a/julee_example/use_cases/validate_document.py
+++ b/julee_example/use_cases/validate_document.py
@@ -660,6 +660,7 @@ class ValidateDocumentUseCase:
 
         # Apply transformations sequentially
         current_content = document.content
+        assert current_content is not None
         current_content.seek(0)
         transformed_content = current_content.read().decode("utf-8")
         current_content.seek(0)


### PR DESCRIPTION
This is another prequel branch for the temporal integration that I'm working on.

## The problem

It is a use-case (extract-assemble-data.py) which calls out to the different knowledge services to extract different sections of the required data, and then the use-case is the one stitching those together to form the final document. Since the use-case deals only with temporal proxies (ie. no concrete implementations), it had no way of *saving* the resulting document content (since the content stream is not included in the serialisation/deserialisation which is required when calling activities like save from a workflow).

## The solution
I tried a couple of different solutions to this, but this one seems the cleanest: include a `content_string` optional attribute on the document model, for use only when saving documents with small content (a few kb) from use-cases/workflows. Any document saves from an activity will be using concrete implementations and so can save with the normal content stream (as there's no temporal serialisation happening on the save, in that case).