### PR TITLE
Knowledge service calls always take config.

### DIFF
--- a/julee_example/services/knowledge_service/__init__.py
+++ b/julee_example/services/knowledge_service/__init__.py
@@ -13,7 +13,7 @@ from .knowledge_service import (
     QueryResult,
     FileRegistrationResult,
 )
-from .factory import knowledge_service_factory
+
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,6 @@ def ensure_knowledge_service(service: object) -> KnowledgeService:
 
 __all__ = [
     "KnowledgeService",
-    "knowledge_service_factory",
     "ensure_knowledge_service",
     "QueryResult",
     "FileRegistrationResult",

--- a/julee_example/services/knowledge_service/anthropic/knowledge_service.py
+++ b/julee_example/services/knowledge_service/anthropic/knowledge_service.py
@@ -14,7 +14,7 @@ import os
 import logging
 import time
 import uuid
-from typing import Optional, List, Dict, Any, cast, IO
+from typing import Optional, List, Dict, Any
 from datetime import datetime, timezone
 
 from anthropic import AsyncAnthropic
@@ -42,27 +42,27 @@ class AnthropicKnowledgeService(KnowledgeService):
     protocol with Anthropic-specific logic.
     """
 
-    def __init__(
-        self,
-        config: KnowledgeServiceConfig,
-    ) -> None:
-        """Initialize Anthropic knowledge service with configuration.
+    def __init__(self) -> None:
+        """Initialize Anthropic knowledge service without configuration.
+
+        Configuration will be provided per method call to maintain
+        stateless operation compatible with Temporal workflows.
+        """
+        # No initialization needed - everything happens per method call
+        pass
+
+    def _get_client(self, config: KnowledgeServiceConfig) -> AsyncAnthropic:
+        """Get an initialized Anthropic client.
 
         Args:
-            config: KnowledgeServiceConfig domain object containing metadata
-                   and service configuration
+            config: KnowledgeServiceConfig (for future extensibility)
+
+        Returns:
+            Configured AsyncAnthropic client instance
+
+        Raises:
+            ValueError: If ANTHROPIC_API_KEY environment variable is not set
         """
-        logger.debug(
-            "Initializing AnthropicKnowledgeService",
-            extra={
-                "knowledge_service_id": config.knowledge_service_id,
-                "service_name": config.name,
-            },
-        )
-
-        self.config = config
-
-        # Initialize Anthropic client
         api_key = os.environ.get("ANTHROPIC_API_KEY")
         if not api_key:
             raise ValueError(
@@ -70,17 +70,18 @@ class AnthropicKnowledgeService(KnowledgeService):
                 "AnthropicKnowledgeService"
             )
 
-        self.client = AsyncAnthropic(
+        return AsyncAnthropic(
             api_key=api_key,
             default_headers={"anthropic-beta": "files-api-2025-04-14"},
         )
 
     async def register_file(
-        self, document: Document
+        self, config: KnowledgeServiceConfig, document: Document
     ) -> FileRegistrationResult:
         """Register a document file with Anthropic.
 
         Args:
+            config: KnowledgeServiceConfig for this operation
             document: Document domain object to register
 
         Returns:
@@ -89,23 +90,30 @@ class AnthropicKnowledgeService(KnowledgeService):
         logger.debug(
             "Registering file with Anthropic",
             extra={
-                "knowledge_service_id": self.config.knowledge_service_id,
+                "knowledge_service_id": config.knowledge_service_id,
                 "document_id": document.document_id,
             },
         )
 
         try:
+            # Get Anthropic client for this operation
+            client = self._get_client(config)
 
-            # Reset stream position and pass stream to Anthropic
-            assert document.content is not None
-            document.content.seek(0)
+            # Ensure content stream is positioned at beginning for upload
+            if document.content:
+                document.content.seek(0)
 
             # Upload file using Anthropic beta Files API
             # Use tuple format: (filename, file_stream, media_type)
-            file_response = await self.client.beta.files.upload(
+            if not document.content:
+                raise ValueError(
+                    "Document content stream is required for upload"
+                )
+
+            file_response = await client.beta.files.upload(
                 file=(
                     document.original_filename,
-                    cast(IO[bytes], document.content.stream),
+                    document.content.stream,  # type: ignore[arg-type]
                     document.content_type,
                 )
             )
@@ -130,7 +138,7 @@ class AnthropicKnowledgeService(KnowledgeService):
             logger.info(
                 "File registered with Anthropic beta Files API",
                 extra={
-                    "knowledge_service_id": self.config.knowledge_service_id,
+                    "knowledge_service_id": config.knowledge_service_id,
                     "document_id": document.document_id,
                     "anthropic_file_id": anthropic_file_id,
                     "original_filename": document.original_filename,
@@ -144,7 +152,7 @@ class AnthropicKnowledgeService(KnowledgeService):
             logger.error(
                 "Failed to register file with Anthropic",
                 extra={
-                    "knowledge_service_id": self.config.knowledge_service_id,
+                    "knowledge_service_id": config.knowledge_service_id,
                     "document_id": document.document_id,
                     "error": str(e),
                 },
@@ -154,6 +162,7 @@ class AnthropicKnowledgeService(KnowledgeService):
 
     async def execute_query(
         self,
+        config: KnowledgeServiceConfig,
         query_text: str,
         service_file_ids: Optional[List[str]] = None,
         query_metadata: Optional[Dict[str, Any]] = None,
@@ -162,6 +171,7 @@ class AnthropicKnowledgeService(KnowledgeService):
         """Execute a query against Anthropic.
 
         Args:
+            config: KnowledgeServiceConfig for this operation
             query_text: The query to execute
             service_file_ids: Optional list of Anthropic file IDs to provide
                              as context for the query
@@ -176,7 +186,7 @@ class AnthropicKnowledgeService(KnowledgeService):
         logger.debug(
             "Executing query with Anthropic",
             extra={
-                "knowledge_service_id": self.config.knowledge_service_id,
+                "knowledge_service_id": config.knowledge_service_id,
                 "query_text": query_text,
                 "document_count": (
                     len(service_file_ids) if service_file_ids else 0
@@ -197,6 +207,9 @@ class AnthropicKnowledgeService(KnowledgeService):
         temperature = metadata.get("temperature")
 
         try:
+            # Get Anthropic client for this operation
+            client = self._get_client(config)
+
             # Prepare the message content with file attachments if provided
             content_parts = []
 
@@ -232,7 +245,7 @@ class AnthropicKnowledgeService(KnowledgeService):
             if temperature is not None:
                 create_params["temperature"] = temperature
 
-            response = await self.client.messages.create(**create_params)
+            response = await client.messages.create(**create_params)
 
             # Calculate execution time
             execution_time_ms = int((time.time() - start_time) * 1000)
@@ -265,7 +278,7 @@ class AnthropicKnowledgeService(KnowledgeService):
             logger.debug(
                 "Single text content block validated and extracted",
                 extra={
-                    "knowledge_service_id": self.config.knowledge_service_id,
+                    "knowledge_service_id": config.knowledge_service_id,
                     "query_id": query_id,
                     "response_length": len(response_text),
                 },
@@ -295,7 +308,7 @@ class AnthropicKnowledgeService(KnowledgeService):
             logger.info(
                 "Query executed with Anthropic successfully",
                 extra={
-                    "knowledge_service_id": self.config.knowledge_service_id,
+                    "knowledge_service_id": config.knowledge_service_id,
                     "query_id": query_id,
                     "execution_time_ms": execution_time_ms,
                     "input_tokens": response.usage.input_tokens,
@@ -313,7 +326,7 @@ class AnthropicKnowledgeService(KnowledgeService):
             logger.error(
                 "Failed to execute query with Anthropic",
                 extra={
-                    "knowledge_service_id": self.config.knowledge_service_id,
+                    "knowledge_service_id": config.knowledge_service_id,
                     "query_id": query_id,
                     "query_text": query_text,
                     "execution_time_ms": execution_time_ms,

--- a/julee_example/services/knowledge_service/anthropic/tests/test_knowledge_service.py
+++ b/julee_example/services/knowledge_service/anthropic/tests/test_knowledge_service.py
@@ -94,12 +94,12 @@ class TestAnthropicKnowledgeService:
         ) as mock_anthropic:
             mock_anthropic.return_value = mock_anthropic_client
 
-            service = anthropic_ks.AnthropicKnowledgeService(
-                knowledge_service_config
-            )
+            service = anthropic_ks.AnthropicKnowledgeService()
 
             query_text = "What is machine learning?"
-            result = await service.execute_query(query_text)
+            result = await service.execute_query(
+                knowledge_service_config, query_text
+            )
 
             # Verify the result structure
             assert result.query_text == query_text
@@ -149,15 +149,14 @@ class TestAnthropicKnowledgeService:
         ) as mock_anthropic:
             mock_anthropic.return_value = mock_anthropic_client
 
-            service = anthropic_ks.AnthropicKnowledgeService(
-                knowledge_service_config
-            )
+            service = anthropic_ks.AnthropicKnowledgeService()
 
-            query_text = "What is in these documents?"
+            query_text = "What is in the document?"
             service_file_ids = ["file_123", "file_456"]
-
             result = await service.execute_query(
-                query_text, service_file_ids=service_file_ids
+                knowledge_service_config,
+                query_text,
+                service_file_ids=service_file_ids,
             )
 
             # Verify the result structure
@@ -203,12 +202,12 @@ class TestAnthropicKnowledgeService:
         ) as mock_anthropic:
             mock_anthropic.return_value = mock_client
 
-            service = anthropic_ks.AnthropicKnowledgeService(
-                knowledge_service_config
-            )
+            service = anthropic_ks.AnthropicKnowledgeService()
 
-            with pytest.raises(Exception, match="API Error"):
-                await service.execute_query("test query")
+            with pytest.raises(Exception):
+                await service.execute_query(
+                    knowledge_service_config, "Test query"
+                )
 
     @patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"})
     async def test_query_id_generation(
@@ -222,13 +221,15 @@ class TestAnthropicKnowledgeService:
         ) as mock_anthropic:
             mock_anthropic.return_value = mock_anthropic_client
 
-            service = anthropic_ks.AnthropicKnowledgeService(
-                knowledge_service_config
-            )
+            service = anthropic_ks.AnthropicKnowledgeService()
 
             # Execute two queries
-            result1 = await service.execute_query("First query")
-            result2 = await service.execute_query("Second query")
+            result1 = await service.execute_query(
+                knowledge_service_config, "First query"
+            )
+            result2 = await service.execute_query(
+                knowledge_service_config, "Second query"
+            )
 
             # Query IDs should be unique and follow expected format
             assert result1.query_id != result2.query_id
@@ -251,13 +252,11 @@ class TestAnthropicKnowledgeService:
         ) as mock_anthropic:
             mock_anthropic.return_value = mock_anthropic_client
 
-            service = anthropic_ks.AnthropicKnowledgeService(
-                knowledge_service_config
-            )
+            service = anthropic_ks.AnthropicKnowledgeService()
 
-            query_text = "Test query"
+            query_text = "What is in the document?"
             result = await service.execute_query(
-                query_text, service_file_ids=[]
+                knowledge_service_config, query_text, service_file_ids=[]
             )
 
             # Should behave the same as None
@@ -281,19 +280,17 @@ class TestAnthropicKnowledgeService:
         ) as mock_anthropic:
             mock_anthropic.return_value = mock_anthropic_client
 
-            service = anthropic_ks.AnthropicKnowledgeService(
-                knowledge_service_config
-            )
+            service = anthropic_ks.AnthropicKnowledgeService()
 
-            query_text = "Custom query with metadata"
             metadata = {
                 "model": "claude-opus-4-1-20250805",
                 "max_tokens": 2000,
                 "temperature": 0.7,
             }
 
+            query_text = "Custom query with metadata"
             result = await service.execute_query(
-                query_text, query_metadata=metadata
+                knowledge_service_config, query_text, query_metadata=metadata
             )
 
             # Verify the result uses metadata values
@@ -320,12 +317,10 @@ class TestAnthropicKnowledgeService:
         ) as mock_anthropic:
             mock_anthropic.return_value = mock_anthropic_client
 
-            service = anthropic_ks.AnthropicKnowledgeService(
-                knowledge_service_config
-            )
+            service = anthropic_ks.AnthropicKnowledgeService()
 
             result = await service.execute_query(
-                "Test query", query_metadata=None
+                knowledge_service_config, "Test query", query_metadata=None
             )
 
             # Verify defaults are used

--- a/julee_example/services/knowledge_service/knowledge_service.py
+++ b/julee_example/services/knowledge_service/knowledge_service.py
@@ -11,9 +11,20 @@ Concrete implementations of this protocol are provided for different external
 services (Anthropic, OpenAI, etc.) and are created via factory functions.
 """
 
-from typing import Protocol, Optional, List, runtime_checkable, Dict, Any
+from typing import (
+    Protocol,
+    Optional,
+    List,
+    runtime_checkable,
+    Dict,
+    Any,
+    TYPE_CHECKING,
+)
 from datetime import datetime, timezone
 from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from julee_example.domain import KnowledgeServiceConfig
 
 from julee_example.domain import Document
 
@@ -69,7 +80,7 @@ class KnowledgeService(Protocol):
     """
 
     async def register_file(
-        self, document: Document
+        self, config: "KnowledgeServiceConfig", document: Document
     ) -> FileRegistrationResult:
         """Register a document file with the external knowledge service.
 
@@ -78,6 +89,7 @@ class KnowledgeService(Protocol):
         future queries.
 
         Args:
+            config: KnowledgeServiceConfig for the service to use
             document: Document domain object to register
 
         Returns:
@@ -100,6 +112,7 @@ class KnowledgeService(Protocol):
 
     async def execute_query(
         self,
+        config: "KnowledgeServiceConfig",
         query_text: str,
         service_file_ids: Optional[List[str]] = None,
         query_metadata: Optional[Dict[str, Any]] = None,
@@ -112,6 +125,7 @@ class KnowledgeService(Protocol):
         previously registered with the service.
 
         Args:
+            config: KnowledgeServiceConfig for the service to use
             query_text: The query to execute (natural language or structured)
             service_file_ids: Optional list of service file IDs to provide as
                              context for the query. These are the IDs returned

--- a/julee_example/services/knowledge_service/test_factory.py
+++ b/julee_example/services/knowledge_service/test_factory.py
@@ -71,7 +71,6 @@ class TestKnowledgeServiceFactory:
             service = knowledge_service_factory(anthropic_config)
 
             assert isinstance(service, AnthropicKnowledgeService)
-            assert service.config == anthropic_config
 
     def test_factory_returns_validated_service(
         self,
@@ -98,7 +97,7 @@ class TestEnsureKnowledgeService:
         # Mock the anthropic import to avoid dependency issues in tests
         with pytest.MonkeyPatch.context() as m:
             m.setenv("ANTHROPIC_API_KEY", "test-key")
-            service = AnthropicKnowledgeService(anthropic_config)
+            service = AnthropicKnowledgeService()
 
             validated_service = ensure_knowledge_service(service)
             assert validated_service == service


### PR DESCRIPTION
So: I have the temporal examples working locally now, but due to the investigative nature of the process, it's nearly 4k of diff.

I've looked for ways to break it up such that tests pass with each, but it's tricky, so I'm instead going to propose a series of 200-500 line PRs which have a concept to review, but each won't pass all checks. I'll be merging them down into the workflow-4.6.0b which this PR targets, rather than main, so we can ensure once everything is reviewed and in that one branch, it's all passing before landing in the main branch.

This PR's main change is to update the individual knowledge service protocol methods: `register_file` and `execute_query` to accept the knowledge service config (rather than it being passed as an init arg). This is so we can know at run-time which knowledge service implementation should be used for the call. Previously I'd planned to instantiate each knowledge service with the config, but the activities we're defining on classes are effectively class methods / stand-alone functions given the way an activity needs to be retried, so storing instance state makes no sense (I actually wonder whether using classes rather than just modules with functions, is actually benefiting us - but not worth devoting time to now).

There are a few other small changes, for which I'll leave comments inline.