### PR TITLE
Update use-cases to new single knowledge service signature.

### DIFF
--- a/julee_example/repositories/minio/client.py
+++ b/julee_example/repositories/minio/client.py
@@ -11,6 +11,7 @@ common patterns used across all Minio repository implementations to reduce
 code duplication and ensure consistent error handling and logging.
 """
 
+import io
 import json
 from datetime import datetime, timezone
 from typing import (
@@ -279,11 +280,12 @@ class MinioRepositoryMixin:
             # Serialize using Pydantic's JSON serialization
             json_data = model.model_dump_json()
 
+            json_bytes = json_data.encode("utf-8")
             self.client.put_object(
                 bucket_name=bucket_name,
                 object_name=object_name,
-                data=json_data.encode("utf-8"),
-                length=len(json_data.encode("utf-8")),
+                data=io.BytesIO(json_bytes),
+                length=len(json_bytes),
                 content_type="application/json",
             )
 

--- a/julee_example/use_cases/tests/test_validate_document.py
+++ b/julee_example/use_cases/tests/test_validate_document.py
@@ -10,6 +10,7 @@ import io
 import pytest
 from unittest.mock import AsyncMock
 from datetime import datetime, timezone
+from pydantic import ValidationError
 
 from julee_example.use_cases.validate_document import ValidateDocumentUseCase
 
@@ -29,8 +30,8 @@ from julee_example.domain.policy import (
 from julee_example.domain.knowledge_service_config import ServiceApi
 from julee_example.repositories.memory import (
     MemoryDocumentRepository,
-    MemoryKnowledgeServiceConfigRepository,
     MemoryKnowledgeServiceQueryRepository,
+    MemoryKnowledgeServiceConfigRepository,
     MemoryPolicyRepository,
     MemoryDocumentPolicyValidationRepository,
 )
@@ -38,7 +39,6 @@ from julee_example.services.knowledge_service.memory import (
     MemoryKnowledgeService,
 )
 from julee_example.services.knowledge_service import QueryResult
-import julee_example.use_cases.validate_document
 
 
 class TestValidateDocumentUseCase:
@@ -76,6 +76,19 @@ class TestValidateDocumentUseCase:
         return MemoryDocumentPolicyValidationRepository()
 
     @pytest.fixture
+    def knowledge_service(self) -> MemoryKnowledgeService:
+        """Create a memory KnowledgeService for testing."""
+        ks_config = KnowledgeServiceConfig(
+            knowledge_service_id="ks-test",
+            name="Test Knowledge Service",
+            description="Test service",
+            service_api=ServiceApi.ANTHROPIC,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        return MemoryKnowledgeService(ks_config)
+
+    @pytest.fixture
     def use_case(
         self,
         document_repo: MemoryDocumentRepository,
@@ -85,6 +98,7 @@ class TestValidateDocumentUseCase:
         document_policy_validation_repo: (
             MemoryDocumentPolicyValidationRepository
         ),
+        knowledge_service: MemoryKnowledgeService,
     ) -> ValidateDocumentUseCase:
         """Create ValidateDocumentUseCase with memory repository
         dependencies."""
@@ -94,6 +108,29 @@ class TestValidateDocumentUseCase:
             knowledge_service_config_repo=knowledge_service_config_repo,
             policy_repo=policy_repo,
             document_policy_validation_repo=document_policy_validation_repo,
+            knowledge_service=knowledge_service,
+        )
+
+    def _create_configured_use_case(
+        self,
+        document_repo: MemoryDocumentRepository,
+        knowledge_service_query_repo: MemoryKnowledgeServiceQueryRepository,
+        knowledge_service_config_repo: MemoryKnowledgeServiceConfigRepository,
+        policy_repo: MemoryPolicyRepository,
+        document_policy_validation_repo: (
+            MemoryDocumentPolicyValidationRepository
+        ),
+        memory_service: MemoryKnowledgeService,
+    ) -> ValidateDocumentUseCase:
+        """Helper to create ValidateDocumentUseCase with configured memory
+        service."""
+        return ValidateDocumentUseCase(
+            document_repo=document_repo,
+            knowledge_service_query_repo=knowledge_service_query_repo,
+            knowledge_service_config_repo=knowledge_service_config_repo,
+            policy_repo=policy_repo,
+            document_policy_validation_repo=document_policy_validation_repo,
+            knowledge_service=memory_service,
         )
 
     @pytest.mark.asyncio
@@ -217,6 +254,9 @@ class TestValidateDocumentUseCase:
         policy_repo: MemoryPolicyRepository,
         knowledge_service_query_repo: MemoryKnowledgeServiceQueryRepository,
         knowledge_service_config_repo: MemoryKnowledgeServiceConfigRepository,
+        document_policy_validation_repo: (
+            MemoryDocumentPolicyValidationRepository
+        ),
     ) -> None:
         """Test that validation fails when score cannot be parsed."""
         # Arrange - Create test document
@@ -282,25 +322,24 @@ class TestValidateDocumentUseCase:
             )
         )
 
-        # Patch the factory to return our configured memory service
-        module = julee_example.use_cases.validate_document
-        original_factory = module.knowledge_service_factory
-        module.knowledge_service_factory = (
-            lambda config: memory_service  # type: ignore[assignment]
+        # Create use case with configured memory service
+        configured_use_case = self._create_configured_use_case(
+            document_repo=document_repo,
+            knowledge_service_query_repo=knowledge_service_query_repo,
+            knowledge_service_config_repo=knowledge_service_config_repo,
+            policy_repo=policy_repo,
+            document_policy_validation_repo=document_policy_validation_repo,
+            memory_service=memory_service,
         )
 
-        try:
-            # Act & Assert
-            with pytest.raises(
-                ValueError,
-                match="Failed to parse numeric score from response",
-            ):
-                await use_case.validate_document(
-                    document_id="doc-123", policy_id="policy-123"
-                )
-        finally:
-            # Restore original factory
-            module.knowledge_service_factory = original_factory
+        # Act & Assert
+        with pytest.raises(
+            ValueError,
+            match="Failed to parse numeric score from response",
+        ):
+            await configured_use_case.validate_document(
+                document_id="doc-123", policy_id="policy-123"
+            )
 
     @pytest.mark.asyncio
     async def test_full_validation_workflow_success_pass(
@@ -406,21 +445,20 @@ class TestValidateDocumentUseCase:
             ]
         )
 
-        # Patch the factory to return our configured memory service
-        module = julee_example.use_cases.validate_document
-        original_factory = module.knowledge_service_factory
-        module.knowledge_service_factory = (
-            lambda config: memory_service  # type: ignore[assignment]
+        # Create use case with configured memory service
+        configured_use_case = self._create_configured_use_case(
+            document_repo=document_repo,
+            knowledge_service_query_repo=knowledge_service_query_repo,
+            knowledge_service_config_repo=knowledge_service_config_repo,
+            policy_repo=policy_repo,
+            document_policy_validation_repo=document_policy_validation_repo,
+            memory_service=memory_service,
         )
 
-        try:
-            # Act
-            result = await use_case.validate_document(
-                document_id="doc-123", policy_id="policy-123"
-            )
-        finally:
-            # Restore original factory
-            module.knowledge_service_factory = original_factory
+        # Act
+        result = await configured_use_case.validate_document(
+            document_id="doc-123", policy_id="policy-123"
+        )
 
         # Assert
         assert isinstance(result, DocumentPolicyValidation)
@@ -518,21 +556,20 @@ class TestValidateDocumentUseCase:
             )
         )
 
-        # Patch the factory to return our configured memory service
-        module = julee_example.use_cases.validate_document
-        original_factory = module.knowledge_service_factory
-        module.knowledge_service_factory = (
-            lambda config: memory_service  # type: ignore[assignment]
+        # Create use case with configured memory service
+        configured_use_case = self._create_configured_use_case(
+            document_repo=document_repo,
+            knowledge_service_query_repo=knowledge_service_query_repo,
+            knowledge_service_config_repo=knowledge_service_config_repo,
+            policy_repo=policy_repo,
+            document_policy_validation_repo=document_policy_validation_repo,
+            memory_service=memory_service,
         )
 
-        try:
-            # Act
-            await use_case.validate_document(
-                document_id="doc-456", policy_id="policy-456"
-            )
-        finally:
-            # Restore original factory
-            module.knowledge_service_factory = original_factory
+        # Act
+        await configured_use_case.validate_document(
+            document_id="doc-456", policy_id="policy-456"
+        )
 
     @pytest.mark.asyncio
     async def test_validation_with_transformation_success(
@@ -649,21 +686,20 @@ class TestValidateDocumentUseCase:
             )
         )
 
-        # Patch the factory to return our configured memory service
-        module = julee_example.use_cases.validate_document
-        original_factory = module.knowledge_service_factory
-        module.knowledge_service_factory = (
-            lambda config: memory_service  # type: ignore[assignment]
+        # Create use case with configured memory service
+        configured_use_case = self._create_configured_use_case(
+            document_repo=document_repo,
+            knowledge_service_query_repo=knowledge_service_query_repo,
+            knowledge_service_config_repo=knowledge_service_config_repo,
+            policy_repo=policy_repo,
+            document_policy_validation_repo=document_policy_validation_repo,
+            memory_service=memory_service,
         )
 
-        try:
-            # Act
-            result = await use_case.validate_document(
-                document_id="doc-transform-1", policy_id="policy-transform-1"
-            )
-        finally:
-            # Restore original factory
-            module.knowledge_service_factory = original_factory
+        # Act
+        result = await configured_use_case.validate_document(
+            document_id="doc-transform-1", policy_id="policy-transform-1"
+        )
 
         # Assert
         assert isinstance(result, DocumentPolicyValidation)
@@ -706,6 +742,9 @@ class TestValidateDocumentUseCase:
         policy_repo: MemoryPolicyRepository,
         knowledge_service_query_repo: MemoryKnowledgeServiceQueryRepository,
         knowledge_service_config_repo: MemoryKnowledgeServiceConfigRepository,
+        document_policy_validation_repo: (
+            MemoryDocumentPolicyValidationRepository
+        ),
     ) -> None:
         """Test validation with transformation that still fails after
         transformation."""
@@ -815,21 +854,20 @@ class TestValidateDocumentUseCase:
             )
         )
 
-        # Patch the factory
-        module = julee_example.use_cases.validate_document
-        original_factory = module.knowledge_service_factory
-        module.knowledge_service_factory = (
-            lambda config: memory_service  # type: ignore[assignment]
+        # Create use case with configured memory service
+        configured_use_case = self._create_configured_use_case(
+            document_repo=document_repo,
+            knowledge_service_query_repo=knowledge_service_query_repo,
+            knowledge_service_config_repo=knowledge_service_config_repo,
+            policy_repo=policy_repo,
+            document_policy_validation_repo=document_policy_validation_repo,
+            memory_service=memory_service,
         )
 
-        try:
-            # Act
-            result = await use_case.validate_document(
-                document_id="doc-transform-2", policy_id="policy-transform-2"
-            )
-        finally:
-            # Restore original factory
-            module.knowledge_service_factory = original_factory
+        # Act
+        result = await configured_use_case.validate_document(
+            document_id="doc-transform-2", policy_id="policy-transform-2"
+        )
 
         # Assert
         assert isinstance(result, DocumentPolicyValidation)
@@ -852,6 +890,9 @@ class TestValidateDocumentUseCase:
         policy_repo: MemoryPolicyRepository,
         knowledge_service_query_repo: MemoryKnowledgeServiceQueryRepository,
         knowledge_service_config_repo: MemoryKnowledgeServiceConfigRepository,
+        document_policy_validation_repo: (
+            MemoryDocumentPolicyValidationRepository
+        ),
     ) -> None:
         """Test that transformation is skipped when initial validation
         passes."""
@@ -931,22 +972,20 @@ class TestValidateDocumentUseCase:
             )
         )
 
-        # Patch the factory
-        module = julee_example.use_cases.validate_document
-        original_factory = module.knowledge_service_factory
-        module.knowledge_service_factory = (
-            lambda config: memory_service  # type: ignore[assignment]
+        # Create use case with configured memory service
+        configured_use_case = self._create_configured_use_case(
+            document_repo=document_repo,
+            knowledge_service_query_repo=knowledge_service_query_repo,
+            knowledge_service_config_repo=knowledge_service_config_repo,
+            policy_repo=policy_repo,
+            document_policy_validation_repo=document_policy_validation_repo,
+            memory_service=memory_service,
         )
 
-        try:
-            # Act
-            result = await use_case.validate_document(
-                document_id="doc-no-transform",
-                policy_id="policy-no-transform",
-            )
-        finally:
-            # Restore original factory
-            module.knowledge_service_factory = original_factory
+        # Act
+        result = await configured_use_case.validate_document(
+            document_id="doc-no-transform", policy_id="policy-no-transform"
+        )
 
         # Assert
         assert isinstance(result, DocumentPolicyValidation)
@@ -967,6 +1006,9 @@ class TestValidateDocumentUseCase:
         policy_repo: MemoryPolicyRepository,
         knowledge_service_query_repo: MemoryKnowledgeServiceQueryRepository,
         knowledge_service_config_repo: MemoryKnowledgeServiceConfigRepository,
+        document_policy_validation_repo: (
+            MemoryDocumentPolicyValidationRepository
+        ),
     ) -> None:
         """Test that transformation fails when result is not valid JSON."""
         # Arrange - Create test document
@@ -1058,25 +1100,25 @@ class TestValidateDocumentUseCase:
             )
         )
 
-        # Patch the factory
-        module = julee_example.use_cases.validate_document
-        original_factory = module.knowledge_service_factory
-        module.knowledge_service_factory = (
-            lambda config: memory_service  # type: ignore[assignment]
+        # Create use case with configured memory service
+        configured_use_case = self._create_configured_use_case(
+            document_repo=document_repo,
+            knowledge_service_query_repo=knowledge_service_query_repo,
+            knowledge_service_config_repo=knowledge_service_config_repo,
+            policy_repo=policy_repo,
+            document_policy_validation_repo=document_policy_validation_repo,
+            memory_service=memory_service,
         )
 
-        try:
-            # Act & Assert
-            with pytest.raises(
-                ValueError, match="Transformation result must be valid JSON"
-            ):
-                await use_case.validate_document(
-                    document_id="doc-invalid-json",
-                    policy_id="policy-invalid-json",
-                )
-        finally:
-            # Restore original factory
-            module.knowledge_service_factory = original_factory
+        # Act & Assert
+        with pytest.raises(
+            ValueError,
+            match="Transformation result must be valid JSON",
+        ):
+            await configured_use_case.validate_document(
+                document_id="doc-invalid-json",
+                policy_id="policy-invalid-json",
+            )
 
     @pytest.mark.asyncio
     async def test_transformation_query_not_found(
@@ -1158,6 +1200,9 @@ class TestValidateDocumentUseCase:
         policy_repo: MemoryPolicyRepository,
         knowledge_service_query_repo: MemoryKnowledgeServiceQueryRepository,
         knowledge_service_config_repo: MemoryKnowledgeServiceConfigRepository,
+        document_policy_validation_repo: (
+            MemoryDocumentPolicyValidationRepository
+        ),
     ) -> None:
         """Test that validation fails when domain model rejects out-of-range
         scores."""
@@ -1222,22 +1267,21 @@ class TestValidateDocumentUseCase:
             )
         )
 
-        # Patch the factory to return our configured memory service
-        module = julee_example.use_cases.validate_document
-        original_factory = module.knowledge_service_factory
-        module.knowledge_service_factory = (
-            lambda config: memory_service  # type: ignore[assignment]
+        # Create use case with configured memory service
+        configured_use_case = self._create_configured_use_case(
+            document_repo=document_repo,
+            knowledge_service_query_repo=knowledge_service_query_repo,
+            knowledge_service_config_repo=knowledge_service_config_repo,
+            policy_repo=policy_repo,
+            document_policy_validation_repo=document_policy_validation_repo,
+            memory_service=memory_service,
         )
 
-        try:
-            # Act & Assert - Domain model should reject out-of-range score
-            with pytest.raises(
-                ValueError,
-                match="must be between 0 and 100",
-            ):
-                await use_case.validate_document(
-                    document_id="doc-789", policy_id="policy-789"
-                )
-        finally:
-            # Restore original factory
-            module.knowledge_service_factory = original_factory
+        # Act & Assert
+        with pytest.raises(
+            ValidationError,
+            match="must be between 0 and 100",
+        ):
+            await configured_use_case.validate_document(
+                document_id="doc-789", policy_id="policy-789"
+            )

--- a/julee_example/worker.py
+++ b/julee_example/worker.py
@@ -1,0 +1,219 @@
+"""
+Temporal worker for julee_example domain workflows and activities.
+
+This worker runs workflows and activities for document processing,
+assembly, and knowledge service operations within the julee_example domain.
+"""
+
+import asyncio
+import logging
+import os
+from temporalio.client import Client
+from temporalio.service import RPCError
+from temporalio.worker import Worker
+from temporalio.contrib.pydantic import pydantic_data_converter
+
+from julee_example.workflows import (
+    ExtractAssembleWorkflow,
+)
+from julee_example.repositories.temporal.activities import (
+    TemporalMinioAssemblyRepository,
+    TemporalMinioAssemblySpecificationRepository,
+    TemporalMinioDocumentRepository,
+    TemporalMinioKnowledgeServiceConfigRepository,
+    TemporalMinioKnowledgeServiceQueryRepository,
+)
+from julee_example.services.temporal.activities import (
+    TemporalKnowledgeService,
+)
+from minio import Minio
+from julee_example.repositories.minio.client import MinioClient
+
+logger = logging.getLogger(__name__)
+
+
+def setup_logging() -> None:
+    """Configure logging based on environment variables"""
+    log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    log_format = os.environ.get(
+        "LOG_FORMAT", "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+
+    # Validate log level
+    numeric_level = getattr(logging, log_level, None)
+    if not isinstance(numeric_level, int):
+        print(f"Invalid log level: {log_level}, defaulting to INFO")
+        numeric_level = logging.INFO
+
+    logging.basicConfig(
+        level=numeric_level,
+        format=log_format,
+        force=True,  # Override any existing configuration
+    )
+
+    logger.info(
+        "Logging configured",
+        extra={"log_level": log_level, "numeric_level": numeric_level},
+    )
+
+
+async def get_temporal_client_with_retries(
+    endpoint: str, attempts: int = 10, delay: int = 5
+) -> Client:
+    """Attempt to connect to Temporal with retries."""
+    logger.debug(
+        "Attempting to connect to Temporal",
+        extra={
+            "endpoint": endpoint,
+            "max_attempts": attempts,
+            "delay_seconds": delay,
+        },
+    )
+
+    for attempt in range(attempts):
+        try:
+            # Use the proper Pydantic v2 data converter and connect to the
+            # 'default' namespace
+            client = await Client.connect(
+                endpoint,
+                data_converter=pydantic_data_converter,
+                namespace="default",
+            )
+            logger.info(
+                "Successfully connected to Temporal",
+                extra={
+                    "endpoint": endpoint,
+                    "attempt": attempt + 1,
+                    "data_converter_type": type(
+                        client.data_converter
+                    ).__name__,
+                },
+            )
+            return client
+        except RPCError as e:
+            logger.warning(
+                "Failed to connect to Temporal",
+                extra={
+                    "endpoint": endpoint,
+                    "attempt": attempt + 1,
+                    "max_attempts": attempts,
+                    "error": str(e),
+                    "retry_in_seconds": delay,
+                },
+            )
+            if attempt + 1 == attempts:
+                logger.error(
+                    "All connection attempts to Temporal failed",
+                    extra={"endpoint": endpoint, "total_attempts": attempts},
+                )
+                raise
+            await asyncio.sleep(delay)
+
+    # This should never be reached due to the raise in the loop, but mypy
+    # needs it
+    raise RuntimeError("Failed to connect to Temporal after all attempts")
+
+
+async def run_worker() -> None:
+    """Run the Temporal worker for julee_example domain"""
+    # Setup logging first
+    setup_logging()
+
+    # Connect to Temporal server using environment variable
+    temporal_endpoint = os.environ.get("TEMPORAL_ENDPOINT", "localhost:7234")
+    logger.info(
+        "Starting julee_example Temporal worker",
+        extra={"temporal_endpoint": temporal_endpoint},
+    )
+
+    client = await get_temporal_client_with_retries(temporal_endpoint)
+
+    # Get Minio endpoint and create client for repositories
+    logger.debug("Preparing repository configurations")
+    minio_endpoint = os.environ.get("MINIO_ENDPOINT", "localhost:9000")
+
+    # Create Minio client for repositories
+    # minio.Minio implements the MinioClient protocol
+    minio_client: MinioClient = Minio(  # type: ignore[assignment]
+        endpoint=minio_endpoint,
+        access_key="minioadmin",
+        secret_key="minioadmin",
+        secure=False,
+    )
+
+    # Instantiate temporal repository classes for activity registration
+    logger.debug("Creating Temporal Activity repository implementations")
+    temporal_assembly_repo = TemporalMinioAssemblyRepository(
+        client=minio_client
+    )
+    temporal_assembly_spec_repo = (
+        TemporalMinioAssemblySpecificationRepository(client=minio_client)
+    )
+    temporal_document_repo = TemporalMinioDocumentRepository(
+        client=minio_client
+    )
+    temporal_knowledge_config_repo = (
+        TemporalMinioKnowledgeServiceConfigRepository(client=minio_client)
+    )
+    temporal_knowledge_query_repo = (
+        TemporalMinioKnowledgeServiceQueryRepository(client=minio_client)
+    )
+
+    # Create temporal knowledge service for activity registration
+    temporal_knowledge_service = TemporalKnowledgeService()
+
+    # Collect all activities from repository instances
+    # The @temporal_activity_registration decorator automatically wraps
+    # all async methods as Temporal activities
+    activities = [
+        # Assembly repository activities
+        temporal_assembly_repo.generate_id,
+        temporal_assembly_repo.save,
+        temporal_assembly_repo.get,
+        # Assembly specification repository activities
+        temporal_assembly_spec_repo.generate_id,
+        temporal_assembly_spec_repo.save,
+        temporal_assembly_spec_repo.get,
+        # Document repository activities
+        temporal_document_repo.generate_id,
+        temporal_document_repo.save,
+        temporal_document_repo.get,
+        # Knowledge service config repository activities
+        temporal_knowledge_config_repo.generate_id,
+        temporal_knowledge_config_repo.save,
+        temporal_knowledge_config_repo.get,
+        # Knowledge service query repository activities
+        temporal_knowledge_query_repo.generate_id,
+        temporal_knowledge_query_repo.save,
+        temporal_knowledge_query_repo.get,
+        # Knowledge service activities
+        temporal_knowledge_service.register_file,
+        temporal_knowledge_service.execute_query,
+    ]
+
+    logger.info(
+        "Creating Temporal worker for julee_example domain",
+        extra={
+            "task_queue": "julee-extract-assemble-queue",
+            "workflow_count": 1,
+            "activity_count": len(activities),
+            "data_converter_type": type(client.data_converter).__name__,
+        },
+    )
+
+    # Create worker with workflow retry policy
+    worker = Worker(
+        client,
+        task_queue="julee-extract-assemble-queue",
+        workflows=[ExtractAssembleWorkflow],
+        activities=activities,  # type: ignore[arg-type]
+    )
+
+    logger.info("Starting julee_example worker execution")
+
+    # Run the worker
+    await worker.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(run_worker())

--- a/julee_example/workflows/__init__.py
+++ b/julee_example/workflows/__init__.py
@@ -1,0 +1,19 @@
+"""
+Temporal workflows for the julee_example domain.
+
+This package contains Temporal workflow definitions that orchestrate
+use cases with durability guarantees, retry logic, and state management.
+
+Workflows in this package:
+- ExtractAssembleWorkflow: Orchestrates document extraction and assembly
+"""
+
+from .extract_assemble import (
+    ExtractAssembleWorkflow,
+    EXTRACT_ASSEMBLE_RETRY_POLICY,
+)
+
+__all__ = [
+    "ExtractAssembleWorkflow",
+    "EXTRACT_ASSEMBLE_RETRY_POLICY",
+]

--- a/julee_example/workflows/extract_assemble.py
+++ b/julee_example/workflows/extract_assemble.py
@@ -1,0 +1,218 @@
+"""
+Temporal workflow for extract and assemble data operations.
+
+This workflow orchestrates the ExtractAssembleDataUseCase with Temporal's
+durability guarantees, providing retry logic, state management, and
+compensation for the complex document assembly process.
+"""
+
+import logging
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+from datetime import timedelta
+
+from julee_example.domain import Assembly
+from julee_example.use_cases.extract_assemble_data import (
+    ExtractAssembleDataUseCase,
+)
+from julee_example.repositories.temporal.proxies import (
+    WorkflowAssemblyRepositoryProxy,
+    WorkflowAssemblySpecificationRepositoryProxy,
+    WorkflowDocumentRepositoryProxy,
+    WorkflowKnowledgeServiceConfigRepositoryProxy,
+    WorkflowKnowledgeServiceQueryRepositoryProxy,
+)
+from julee_example.services.temporal.proxies import (
+    WorkflowKnowledgeServiceProxy,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@workflow.defn
+class ExtractAssembleWorkflow:
+    """
+    Temporal workflow for document extract and assemble operations.
+
+    This workflow:
+    1. Receives document_id and assembly_specification_id
+    2. Orchestrates the ExtractAssembleDataUseCase with workflow-safe proxies
+    3. Provides durability and retry logic for long-running assembly
+    4. Returns the completed Assembly object
+
+    The workflow remains framework-agnostic by delegating all business logic
+    to the use case, while providing Temporal-specific orchestration concerns
+    like retry policies, timeouts, and state management.
+    """
+
+    def __init__(self) -> None:
+        self.current_step = "initialized"
+        self.assembly_id: str | None = None
+
+    @workflow.query
+    def get_current_step(self) -> str:
+        """Query method to get the current workflow step"""
+        return self.current_step
+
+    @workflow.query
+    def get_assembly_id(self) -> str | None:
+        """Query method to get the assembly ID once created"""
+        return self.assembly_id
+
+    @workflow.run
+    async def run(
+        self, document_id: str, assembly_specification_id: str
+    ) -> Assembly:
+        """
+        Execute the extract and assemble workflow.
+
+        Args:
+            document_id: ID of the document to assemble
+            assembly_specification_id: ID of the specification to use
+
+        Returns:
+            Completed Assembly object with assembled document
+
+        Raises:
+            ValueError: If required entities are not found
+            RuntimeError: If assembly processing fails after retries
+        """
+        workflow.logger.info(
+            "Starting extract assemble workflow",
+            extra={
+                "document_id": document_id,
+                "assembly_specification_id": assembly_specification_id,
+                "workflow_id": workflow.info().workflow_id,
+                "run_id": workflow.info().run_id,
+            },
+        )
+
+        self.current_step = "initializing_repositories"
+
+        try:
+            # Create workflow-safe repository proxies
+            # These proxy all calls through Temporal activities for durability
+            document_repo = WorkflowDocumentRepositoryProxy()  # type: ignore[abstract]
+            assembly_repo = WorkflowAssemblyRepositoryProxy()  # type: ignore[abstract]
+            assembly_specification_repo = (
+                WorkflowAssemblySpecificationRepositoryProxy()  # type: ignore[abstract]
+            )
+            knowledge_service_query_repo = (
+                WorkflowKnowledgeServiceQueryRepositoryProxy()  # type: ignore[abstract]
+            )
+            knowledge_service_config_repo = (
+                WorkflowKnowledgeServiceConfigRepositoryProxy()  # type: ignore[abstract]
+            )
+
+            workflow.logger.debug(
+                "Repository proxies created",
+                extra={
+                    "document_id": document_id,
+                    "assembly_specification_id": assembly_specification_id,
+                },
+            )
+
+            self.current_step = "creating_use_case"
+
+            # Create workflow-safe knowledge service proxy
+            knowledge_service = WorkflowKnowledgeServiceProxy()  # type: ignore[abstract]
+
+            # Create the use case with workflow-safe repositories
+            # The use case remains completely unaware it's running in workflow
+            use_case = ExtractAssembleDataUseCase(
+                document_repo=document_repo,
+                assembly_repo=assembly_repo,
+                assembly_specification_repo=assembly_specification_repo,
+                knowledge_service_query_repo=knowledge_service_query_repo,
+                knowledge_service_config_repo=knowledge_service_config_repo,
+                knowledge_service=knowledge_service,
+                now_fn=workflow.now,
+            )
+
+            workflow.logger.debug(
+                "Use case created successfully",
+                extra={
+                    "document_id": document_id,
+                    "assembly_specification_id": assembly_specification_id,
+                },
+            )
+
+            self.current_step = "executing_assembly"
+
+            # Execute the assembly process with workflow durability
+            # All repository calls inside the use case will be executed as
+            # Temporal activities with automatic retry and state persistence
+            assembly = await use_case.assemble_data(
+                document_id=document_id,
+                assembly_specification_id=assembly_specification_id,
+            )
+
+            # Store the assembly ID for queries
+            self.assembly_id = assembly.assembly_id
+
+            self.current_step = "completed"
+
+            workflow.logger.info(
+                "Extract assemble workflow completed successfully",
+                extra={
+                    "document_id": document_id,
+                    "assembly_specification_id": assembly_specification_id,
+                    "assembly_id": assembly.assembly_id,
+                    "assembled_document_id": assembly.assembled_document_id,
+                    "status": assembly.status.value,
+                },
+            )
+
+            return assembly
+
+        except Exception as e:
+            self.current_step = "failed"
+
+            workflow.logger.error(
+                "Extract assemble workflow failed",
+                extra={
+                    "document_id": document_id,
+                    "assembly_specification_id": assembly_specification_id,
+                    "assembly_id": self.assembly_id,
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
+                exc_info=True,
+            )
+
+            # Re-raise to let Temporal handle retry logic
+            raise
+
+    @workflow.signal
+    async def cancel_assembly(self, reason: str) -> None:
+        """
+        Signal handler to cancel the assembly process.
+
+        Args:
+            reason: Reason for cancellation
+
+        Note:
+            This is a placeholder for future cancellation logic.
+            Currently, we rely on Temporal's built-in workflow cancellation.
+        """
+        workflow.logger.info(
+            "Assembly cancellation requested",
+            extra={
+                "assembly_id": self.assembly_id,
+                "reason": reason,
+                "current_step": self.current_step,
+            },
+        )
+
+        # Future: Implement graceful cancellation logic here
+        # For now, let the workflow be cancelled naturally by Temporal
+
+
+# Workflow configuration with retry policies optimized for document processing
+EXTRACT_ASSEMBLE_RETRY_POLICY = RetryPolicy(
+    initial_interval=timedelta(seconds=1),
+    backoff_coefficient=2.0,
+    maximum_interval=timedelta(minutes=5),
+    maximum_attempts=5,
+    non_retryable_error_types=["ValueError"],  # Don't retry validation errors
+)

--- a/util/repos/temporal/decorators.py
+++ b/util/repos/temporal/decorators.py
@@ -410,12 +410,14 @@ def temporal_workflow_proxy(
                     # Prepare arguments (exclude self)
                     activity_args = args if args else ()
 
-                    # Note: kwargs not currently supported by this decorator
-                    # Most repository methods use positional args only
+                    # Handle kwargs - Temporal doesn't support kwargs directly
                     if kwargs:
                         raise ValueError(
-                            f"kwargs not supported in workflow proxy "
-                            f"for {method_name}. Use positional args."
+                            f"Keyword arguments not supported in workflow "
+                            f"proxy for {method_name}. Temporal activities "
+                            f"only accept positional arguments. Please "
+                            f"modify the calling code to use positional "
+                            f"arguments instead of: {list(kwargs.keys())}"
                         )
 
                     # Execute the activity


### PR DESCRIPTION
Following #59, this PR updates the two workflows (extract-assemble-data and validate-document) to use the single knowledge service which takes the config as an arg for `register_file` and `execute_query`.