### PR TITLE
Add new examples for demo'ing temporal workflow.

### DIFF
--- a/julee_example/domain/document/tests/test_document.py
+++ b/julee_example/domain/document/tests/test_document.py
@@ -274,3 +274,28 @@ class TestDocumentContentValidation:
 
         assert doc.content is None
         assert doc.content_string == content_string
+
+    def test_document_deserialization_with_empty_content_succeeds(
+        self,
+    ) -> None:
+        """Test Temporal deserialization allows empty content."""
+        # This simulates what happens when a Document comes back from Temporal
+        # activities - the ContentStream is excluded from serialization
+        document_data = {
+            "document_id": "test-temporal",
+            "original_filename": "temporal.json",
+            "content_type": "application/json",
+            "size_bytes": 100,
+            "content_multihash": "test_hash",
+            "content": None,
+            "content_string": None,
+        }
+
+        # Should succeed with temporal_validation context
+        doc = Document.model_validate(
+            document_data, context={"temporal_validation": True}
+        )
+
+        assert doc.document_id == "test-temporal"
+        assert doc.content is None
+        assert doc.content_string is None

--- a/julee_example/examples/anthropic_apply_policy.py
+++ b/julee_example/examples/anthropic_apply_policy.py
@@ -68,10 +68,13 @@ from julee_example.domain.policy import (
 from julee_example.domain.knowledge_service_config import ServiceApi
 from julee_example.repositories.memory import (
     MemoryDocumentRepository,
+    MemoryDocumentPolicyValidationRepository,
     MemoryKnowledgeServiceConfigRepository,
     MemoryKnowledgeServiceQueryRepository,
     MemoryPolicyRepository,
-    MemoryDocumentPolicyValidationRepository,
+)
+from julee_example.services.knowledge_service.memory import (
+    MemoryKnowledgeService,
 )
 from julee_example.use_cases.validate_document import (
     ValidateDocumentUseCase,
@@ -466,13 +469,25 @@ async def test_validate_document_use_case(
             input_file_path, policy_file_path
         )
 
-        # Create the use case
+        # Create the use case with knowledge service
+        # Create a test config for the memory knowledge service
+        test_config = KnowledgeServiceConfig(
+            knowledge_service_id="ks-example",
+            name="Example Knowledge Service",
+            description="Memory service for example",
+            service_api=ServiceApi.ANTHROPIC,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        knowledge_service = MemoryKnowledgeService(test_config)
+
         use_case = ValidateDocumentUseCase(
             document_repo=document_repo,
             knowledge_service_query_repo=ks_query_repo,
             knowledge_service_config_repo=ks_config_repo,
             policy_repo=policy_repo,
             document_policy_validation_repo=document_policy_validation_repo,
+            knowledge_service=knowledge_service,
         )
 
         print("\n✅ Created ValidateDocumentUseCase with all repositories")

--- a/julee_example/examples/anthropic_assemble_data.py
+++ b/julee_example/examples/anthropic_assemble_data.py
@@ -69,6 +69,9 @@ from julee_example.repositories.memory import (
     MemoryKnowledgeServiceConfigRepository,
     MemoryKnowledgeServiceQueryRepository,
 )
+from julee_example.services.knowledge_service.memory import (
+    MemoryKnowledgeService,
+)
 from julee_example.use_cases.extract_assemble_data import (
     ExtractAssembleDataUseCase,
 )
@@ -453,13 +456,25 @@ async def test_assemble_data_use_case(
             input_file_path, spec_file_path
         )
 
-        # Create the use case
+        # Create the use case with knowledge service
+        # Create a test config for the memory knowledge service
+        test_config = KnowledgeServiceConfig(
+            knowledge_service_id="ks-example",
+            name="Example Knowledge Service",
+            description="Memory service for example",
+            service_api=ServiceApi.ANTHROPIC,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        knowledge_service = MemoryKnowledgeService(test_config)
+
         use_case = ExtractAssembleDataUseCase(
             document_repo=document_repo,
             assembly_repo=assembly_repo,
             assembly_specification_repo=assembly_spec_repo,
             knowledge_service_query_repo=ks_query_repo,
             knowledge_service_config_repo=ks_config_repo,
+            knowledge_service=knowledge_service,
         )
 
         print("\n✅ Created ExtractAssembleDataUseCase with all repositories")

--- a/julee_example/examples/client_example.py
+++ b/julee_example/examples/client_example.py
@@ -11,7 +11,7 @@ import logging
 import os
 from typing import Optional
 from temporalio.client import Client
-from temporalio.contrib.pydantic import pydantic_data_converter
+from util.repos.temporal.data_converter import temporal_data_converter
 from minio import Minio
 
 from julee_example.workflows import (
@@ -49,7 +49,7 @@ async def start_extract_assemble_workflow(
     # Connect to Temporal
     client = await Client.connect(
         temporal_endpoint,
-        data_converter=pydantic_data_converter,
+        data_converter=temporal_data_converter,
         namespace="default",
     )
 
@@ -107,7 +107,7 @@ async def wait_for_workflow_result(
     # Connect to Temporal
     client = await Client.connect(
         temporal_endpoint,
-        data_converter=pydantic_data_converter,
+        data_converter=temporal_data_converter,
         namespace="default",
     )
 
@@ -185,7 +185,7 @@ async def query_workflow_status(
     # Connect to Temporal
     client = await Client.connect(
         temporal_endpoint,
-        data_converter=pydantic_data_converter,
+        data_converter=temporal_data_converter,
         namespace="default",
     )
 
@@ -238,7 +238,7 @@ async def cancel_workflow(
     # Connect to Temporal
     client = await Client.connect(
         temporal_endpoint,
-        data_converter=pydantic_data_converter,
+        data_converter=temporal_data_converter,
         namespace="default",
     )
 

--- a/julee_example/examples/client_example.py
+++ b/julee_example/examples/client_example.py
@@ -1,0 +1,394 @@
+"""
+Example client for starting ExtractAssemble workflows in julee_example.
+
+This demonstrates how to start document extraction and assembly workflows
+using Temporal's client API. It shows proper workflow configuration,
+error handling, and result retrieval.
+"""
+
+import asyncio
+import logging
+import os
+from typing import Optional
+from temporalio.client import Client
+from temporalio.contrib.pydantic import pydantic_data_converter
+from minio import Minio
+
+from julee_example.workflows import (
+    ExtractAssembleWorkflow,
+    EXTRACT_ASSEMBLE_RETRY_POLICY,
+)
+from julee_example.domain import Assembly
+from julee_example.examples.populate_example_data import populate_example_data
+from julee_example.repositories.minio.document import MinioDocumentRepository
+
+logger = logging.getLogger(__name__)
+
+
+async def start_extract_assemble_workflow(
+    temporal_endpoint: str,
+    document_id: str,
+    assembly_specification_id: str,
+    workflow_id: Optional[str] = None,
+) -> str:
+    """
+    Start an ExtractAssemble workflow.
+
+    Args:
+        temporal_endpoint: Temporal server endpoint
+        document_id: ID of the document to assemble
+        assembly_specification_id: ID of the specification to use
+        workflow_id: Optional custom workflow ID (generated if not provided)
+
+    Returns:
+        The workflow ID of the started workflow
+
+    Raises:
+        Exception: If workflow start fails
+    """
+    # Connect to Temporal
+    client = await Client.connect(
+        temporal_endpoint,
+        data_converter=pydantic_data_converter,
+        namespace="default",
+    )
+
+    # Generate workflow ID if not provided
+    if not workflow_id:
+        workflow_id = (
+            f"extract-assemble-{document_id}-{assembly_specification_id}"
+        )
+
+    logger.info(
+        "Starting ExtractAssemble workflow",
+        extra={
+            "workflow_id": workflow_id,
+            "document_id": document_id,
+            "assembly_specification_id": assembly_specification_id,
+        },
+    )
+
+    # Start the workflow
+    handle = await client.start_workflow(
+        ExtractAssembleWorkflow.run,
+        args=[document_id, assembly_specification_id],
+        id=workflow_id,
+        task_queue="julee-extract-assemble-queue",
+        retry_policy=EXTRACT_ASSEMBLE_RETRY_POLICY,
+    )
+
+    logger.info(
+        "ExtractAssemble workflow started successfully",
+        extra={
+            "workflow_id": workflow_id,
+            "run_id": handle.run_id,
+        },
+    )
+
+    return workflow_id
+
+
+async def wait_for_workflow_result(
+    temporal_endpoint: str, workflow_id: str
+) -> Assembly:
+    """
+    Wait for a workflow to complete and return its result.
+
+    Args:
+        temporal_endpoint: Temporal server endpoint
+        workflow_id: ID of the workflow to wait for
+
+    Returns:
+        The Assembly result from the workflow
+
+    Raises:
+        Exception: If workflow fails or times out
+    """
+    # Connect to Temporal
+    client = await Client.connect(
+        temporal_endpoint,
+        data_converter=pydantic_data_converter,
+        namespace="default",
+    )
+
+    # Get workflow handle
+    handle = client.get_workflow_handle(workflow_id)
+
+    logger.info(
+        "Waiting for workflow completion", extra={"workflow_id": workflow_id}
+    )
+
+    try:
+        # Wait for the workflow result
+        result = await handle.result()
+
+        # Debug: Check what we actually got back
+        print(f"DEBUG: Workflow result type: {type(result)}")
+        print(f"DEBUG: Workflow result value: {result}")
+
+        if not isinstance(result, Assembly):
+            print(f"DEBUG: Expected Assembly, got {type(result)}")
+            if isinstance(result, dict):
+                print("DEBUG: Converting dict to Assembly object")
+                print(f"Dict keys: {list(result.keys())}")
+                try:
+                    # Convert dict back to Assembly object
+                    result = Assembly(**result)
+                    print("DEBUG: Successfully converted dict to Assembly")
+                except Exception as e:
+                    print(f"DEBUG: Failed to convert dict to Assembly: {e}")
+                    print(f"Dict content: {result}")
+                    raise
+            else:
+                raise ValueError(
+                    f"Workflow returned {type(result)} instead of Assembly"
+                )
+
+        logger.info(
+            "Workflow completed successfully",
+            extra={
+                "workflow_id": workflow_id,
+                "assembly_id": result.assembly_id,
+                "status": result.status.value,
+                "assembled_document_id": result.assembled_document_id,
+            },
+        )
+
+        return result
+
+    except Exception as e:
+        logger.error(
+            "Workflow failed",
+            extra={
+                "workflow_id": workflow_id,
+                "error": str(e),
+                "error_type": type(e).__name__,
+            },
+            exc_info=True,
+        )
+        raise
+
+
+async def query_workflow_status(
+    temporal_endpoint: str, workflow_id: str
+) -> dict:
+    """
+    Query the current status of a running workflow.
+
+    Args:
+        temporal_endpoint: Temporal server endpoint
+        workflow_id: ID of the workflow to query
+
+    Returns:
+        Dict containing current step and assembly ID (if available)
+    """
+    # Connect to Temporal
+    client = await Client.connect(
+        temporal_endpoint,
+        data_converter=pydantic_data_converter,
+        namespace="default",
+    )
+
+    # Get workflow handle
+    handle = client.get_workflow_handle(workflow_id)
+
+    try:
+        # Query the current step
+        current_step = await handle.query(
+            ExtractAssembleWorkflow.get_current_step
+        )
+        assembly_id = await handle.query(
+            ExtractAssembleWorkflow.get_assembly_id
+        )
+
+        status = {
+            "workflow_id": workflow_id,
+            "current_step": current_step,
+            "assembly_id": assembly_id,
+        }
+
+        logger.info("Workflow status queried", extra=status)
+
+        return status
+
+    except Exception as e:
+        logger.error(
+            "Failed to query workflow status",
+            extra={
+                "workflow_id": workflow_id,
+                "error": str(e),
+            },
+        )
+        raise
+
+
+async def cancel_workflow(
+    temporal_endpoint: str,
+    workflow_id: str,
+    reason: str = "User requested cancellation",
+) -> None:
+    """
+    Cancel a running workflow.
+
+    Args:
+        temporal_endpoint: Temporal server endpoint
+        workflow_id: ID of the workflow to cancel
+        reason: Reason for cancellation
+    """
+    # Connect to Temporal
+    client = await Client.connect(
+        temporal_endpoint,
+        data_converter=pydantic_data_converter,
+        namespace="default",
+    )
+
+    # Get workflow handle
+    handle = client.get_workflow_handle(workflow_id)
+
+    try:
+        # Send cancellation signal
+        await handle.signal(ExtractAssembleWorkflow.cancel_assembly, reason)
+
+        # Also cancel the workflow execution
+        await handle.cancel()
+
+        logger.info(
+            "Workflow cancelled",
+            extra={
+                "workflow_id": workflow_id,
+                "reason": reason,
+            },
+        )
+
+    except Exception as e:
+        logger.error(
+            "Failed to cancel workflow",
+            extra={
+                "workflow_id": workflow_id,
+                "error": str(e),
+            },
+        )
+        raise
+
+
+async def fetch_assembled_document_content(document_id: str) -> Optional[str]:
+    """
+    Fetch the assembled document content from MinIO and return it as a string.
+
+    Args:
+        document_id: ID of the assembled document to fetch
+
+    Returns:
+        The document content as a string, or None if not found
+    """
+    try:
+        # Initialize MinIO client
+        minio_endpoint = os.environ.get("MINIO_ENDPOINT", "localhost:9000")
+        minio_client = Minio(
+            endpoint=minio_endpoint,
+            access_key="minioadmin",
+            secret_key="minioadmin",
+            secure=False,
+        )
+
+        # Create document repository
+        doc_repo = MinioDocumentRepository(minio_client)
+
+        # Fetch the document
+        document = await doc_repo.get(document_id)
+        if not document or not document.content:
+            print(f"Document {document_id} not found or has no content")
+            return None
+
+        # Read the content (stream is already at beginning)
+        content_bytes = document.content.read()
+        content_str = content_bytes.decode("utf-8")
+
+        return content_str
+
+    except Exception as e:
+        print(f"Error fetching document {document_id}: {e}")
+        return None
+
+
+async def main() -> None:
+    """
+    Example usage of the ExtractAssemble workflow client.
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    # Get temporal endpoint once
+    temporal_endpoint = os.environ.get("TEMPORAL_ENDPOINT", "localhost:7234")
+    print(f"Using Temporal endpoint: {temporal_endpoint}")
+
+    try:
+        # First, populate example data
+        print("Populating example data...")
+        example_data = await populate_example_data()
+
+        # Extract the IDs we need for the workflow
+        document_id = example_data["document_id"]
+        assembly_specification_id = example_data["assembly_specification_id"]
+
+        print(f"Using document ID: {document_id}")
+        print(f"Using assembly specification ID: {assembly_specification_id}")
+
+        # Start the workflow
+        workflow_id = await start_extract_assemble_workflow(
+            temporal_endpoint=temporal_endpoint,
+            document_id=document_id,
+            assembly_specification_id=assembly_specification_id,
+        )
+
+        # Query status periodically
+        for i in range(3):
+            await asyncio.sleep(2)  # Wait a bit between queries
+            status = await query_workflow_status(
+                temporal_endpoint, workflow_id
+            )
+            print(f"Status check {i+1}: {status}")
+
+        # Wait for completion (in production, you might want a timeout)
+        print("Waiting for workflow to complete...")
+        result = await wait_for_workflow_result(
+            temporal_endpoint, workflow_id
+        )
+
+        print(f"Workflow completed! Assembly ID: {result.assembly_id}")
+        print(f"Assembled document ID: {result.assembled_document_id}")
+        print(f"Final status: {result.status.value}")
+
+        # Fetch and display the assembled document content
+        if result.assembled_document_id:
+            print("\n" + "=" * 50)
+            print("ASSEMBLED DOCUMENT CONTENT:")
+            print("=" * 50)
+
+            content = await fetch_assembled_document_content(
+                result.assembled_document_id
+            )
+            if content:
+                print(content)
+            else:
+                print("No content found or failed to fetch content")
+
+            print("=" * 50)
+
+    except KeyboardInterrupt:
+        print("\nCancelling workflow due to user interrupt...")
+        if "workflow_id" in locals():
+            await cancel_workflow(
+                temporal_endpoint, workflow_id, "User interrupted"
+            )
+    except Exception as e:
+        print(f"Error: {e}")
+        import traceback
+
+        traceback.print_exc()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/julee_example/examples/populate_example_data.py
+++ b/julee_example/examples/populate_example_data.py
@@ -1,0 +1,358 @@
+"""
+Script to populate example data for julee_example workflows.
+
+This script loads the example data files (meeting transcript, assembly spec,
+knowledge service queries) and stores them in the repositories so that
+the workflow examples can use real data instead of hardcoded IDs.
+"""
+
+import asyncio
+import io
+import json
+import logging
+import os
+from pathlib import Path
+from datetime import datetime, timezone
+from typing import Dict
+
+from minio import Minio
+
+from julee_example.domain import (
+    Document,
+    DocumentStatus,
+    ContentStream,
+    AssemblySpecification,
+    KnowledgeServiceQuery,
+    KnowledgeServiceConfig,
+)
+from julee_example.domain.knowledge_service_config import ServiceApi
+from julee_example.repositories.minio.assembly_specification import (
+    MinioAssemblySpecificationRepository,
+)
+from julee_example.repositories.minio.document import MinioDocumentRepository
+from julee_example.repositories.minio.knowledge_service_query import (
+    MinioKnowledgeServiceQueryRepository,
+)
+from julee_example.repositories.minio.knowledge_service_config import (
+    MinioKnowledgeServiceConfigRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def setup_logging() -> None:
+    """Configure logging for the populate script."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+
+async def create_minio_client() -> Minio:
+    """Create and return a Minio client."""
+    minio_endpoint = os.environ.get("MINIO_ENDPOINT", "localhost:9000")
+
+    return Minio(
+        endpoint=minio_endpoint,
+        access_key="minioadmin",
+        secret_key="minioadmin",
+        secure=False,
+    )
+
+
+async def load_example_document(
+    document_repo: MinioDocumentRepository,
+    data_dir: Path,
+) -> str:
+    """
+    Load the meeting transcript as a document.
+
+    Returns:
+        The document_id of the loaded document
+    """
+    transcript_path = data_dir / "meeting_transcript.txt"
+
+    logger.info(f"Loading meeting transcript from {transcript_path}")
+
+    # Read the transcript content
+    with open(transcript_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    content_bytes = content.encode("utf-8")
+    content_stream = ContentStream(io.BytesIO(content_bytes))
+
+    # Generate document ID
+    document_id = await document_repo.generate_id()
+
+    # Create the document
+    document = Document(
+        document_id=document_id,
+        original_filename="meeting_transcript.txt",
+        content_type="text/plain",
+        size_bytes=len(content_bytes),
+        content_multihash="placeholder_hash",  # Would normally calculate this
+        status=DocumentStatus.CAPTURED,
+        content=content_stream,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+    # Save the document
+    await document_repo.save(document)
+
+    logger.info(f"Document saved with ID: {document_id}")
+    return document_id
+
+
+async def load_assembly_specification(
+    assembly_spec_repo: MinioAssemblySpecificationRepository,
+    data_dir: Path,
+    query_ids: Dict[str, str],
+) -> str:
+    """
+    Load the meeting minutes assembly specification.
+
+    Args:
+        assembly_spec_repo: Repository for assembly specifications
+        data_dir: Directory containing the spec file
+        query_ids: Mapping of query names to actual generated IDs
+
+    Returns:
+        The assembly_specification_id of the loaded spec
+    """
+    spec_path = data_dir / "meeting_minutes_assembly_spec.json"
+
+    logger.info(f"Loading assembly specification from {spec_path}")
+
+    # Read and parse the spec file
+    with open(spec_path, "r", encoding="utf-8") as f:
+        spec_data = json.load(f)
+
+    # Generate assembly specification ID
+    spec_id = await assembly_spec_repo.generate_id()
+
+    # Update knowledge_service_queries to use actual generated IDs
+    updated_queries = {}
+    for json_pointer, old_query_name in spec_data[
+        "knowledge_service_queries"
+    ].items():
+        # Map old hardcoded names to actual query IDs
+        if old_query_name == "extract-meeting-info-query":
+            updated_queries[json_pointer] = query_ids["extract_meeting_info"]
+        elif old_query_name == "extract-agenda-items-query":
+            updated_queries[json_pointer] = query_ids["extract_agenda_items"]
+        elif old_query_name == "extract-action-items-query":
+            updated_queries[json_pointer] = query_ids["extract_action_items"]
+        else:
+            logger.warning(f"Unknown query reference: {old_query_name}")
+            updated_queries[json_pointer] = old_query_name
+
+    # Create the assembly specification
+    assembly_spec = AssemblySpecification(
+        assembly_specification_id=spec_id,
+        name=spec_data["name"],
+        applicability=spec_data["applicability"],
+        jsonschema=spec_data["jsonschema"],
+        knowledge_service_queries=updated_queries,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+    # Save the assembly specification
+    await assembly_spec_repo.save(assembly_spec)
+
+    logger.info(f"Assembly specification saved with ID: {spec_id}")
+    return spec_id
+
+
+async def load_knowledge_service_queries(
+    query_repo: MinioKnowledgeServiceQueryRepository,
+    data_dir: Path,
+    knowledge_service_config_id: str,
+) -> Dict[str, str]:
+    """
+    Load all knowledge service queries.
+
+    Args:
+        query_repo: Repository for knowledge service queries
+        data_dir: Directory containing the query files
+        knowledge_service_config_id: Actual generated knowledge service
+            config ID
+
+    Returns:
+        Dict mapping query names to query IDs
+    """
+    query_files = [
+        "extract-meeting-info-query.json",
+        "extract-agenda-items-query.json",
+        "extract-action-items-query.json",
+    ]
+
+    query_ids = {}
+
+    for query_file in query_files:
+        query_path = data_dir / query_file
+
+        logger.info(f"Loading knowledge service query from {query_path}")
+
+        # Read and parse the query file
+        with open(query_path, "r", encoding="utf-8") as f:
+            query_data = json.load(f)
+
+        # Generate query ID
+        query_id = await query_repo.generate_id()
+
+        # Create the knowledge service query with actual config ID
+        query = KnowledgeServiceQuery(
+            query_id=query_id,
+            name=query_data["name"],
+            knowledge_service_id=knowledge_service_config_id,  # Use actual ID
+            prompt=query_data["prompt"],
+            query_metadata=query_data["query_metadata"],
+            assistant_prompt=query_data.get("assistant_prompt"),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+        # Save the query
+        await query_repo.save(query)
+
+        # Store the mapping using the filename (without extension) as key
+        query_name = query_file.replace("-query.json", "").replace("-", "_")
+        query_ids[query_name] = query_id
+
+        logger.info(
+            f"Knowledge service query '{query_data['name']}' saved with ID: "
+            f"{query_id}"
+        )
+
+    return query_ids
+
+
+async def create_anthropic_knowledge_service_config(
+    config_repo: MinioKnowledgeServiceConfigRepository,
+) -> str:
+    """
+    Create the Anthropic knowledge service configuration.
+
+    Returns:
+        The knowledge service config ID
+    """
+    logger.info("Creating Anthropic knowledge service configuration")
+
+    # Generate config ID
+    config_id = await config_repo.generate_id()
+
+    # Create the knowledge service configuration
+    # Note: This is a basic configuration - in practice you'd want
+    # actual API keys and more detailed configuration
+    config = KnowledgeServiceConfig(
+        knowledge_service_id=config_id,
+        name="Anthropic Knowledge Service",
+        description="Anthropic Claude API for document analysis",
+        service_api=ServiceApi.ANTHROPIC,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+    # Save the configuration
+    await config_repo.save(config)
+
+    logger.info(
+        f"Anthropic knowledge service configuration saved with ID: "
+        f"{config_id}"
+    )
+    return config_id
+
+
+async def populate_example_data() -> Dict[str, str]:
+    """
+    Populate all example data and return the IDs for use in workflows.
+
+    Returns:
+        Dict containing the IDs of all created entities:
+        {
+            "document_id": "...",
+            "assembly_specification_id": "...",
+            "knowledge_service_config_id": "...",
+            "extract_meeting_info_query_id": "...",
+            "extract_agenda_items_query_id": "...",
+            "extract_action_items_query_id": "...",
+        }
+    """
+    logger.info("Starting example data population")
+
+    # Get the data directory
+    current_dir = Path(__file__).parent
+    data_dir = current_dir / "data"
+
+    if not data_dir.exists():
+        raise FileNotFoundError(f"Data directory not found: {data_dir}")
+
+    # Create Minio client
+    minio_client = await create_minio_client()
+
+    # Create repository instances
+    document_repo = MinioDocumentRepository(client=minio_client)
+    assembly_spec_repo = MinioAssemblySpecificationRepository(
+        client=minio_client
+    )
+    query_repo = MinioKnowledgeServiceQueryRepository(client=minio_client)
+    config_repo = MinioKnowledgeServiceConfigRepository(client=minio_client)
+
+    # Load all the data (create config first so queries can reference it)
+    document_id = await load_example_document(document_repo, data_dir)
+    config_id = await create_anthropic_knowledge_service_config(config_repo)
+    query_ids = await load_knowledge_service_queries(
+        query_repo, data_dir, config_id
+    )
+    assembly_spec_id = await load_assembly_specification(
+        assembly_spec_repo, data_dir, query_ids
+    )
+
+    # Prepare the result
+    result = {
+        "document_id": document_id,
+        "assembly_specification_id": assembly_spec_id,
+        "knowledge_service_config_id": config_id,
+        **{
+            f"{name}_query_id": query_id
+            for name, query_id in query_ids.items()
+        },
+    }
+
+    logger.info("Example data population completed successfully")
+    logger.info("Created entities:")
+    for key, value in result.items():
+        logger.info(f"  {key}: {value}")
+
+    return result
+
+
+async def main() -> Dict[str, str]:
+    """Main function to populate example data."""
+    setup_logging()
+
+    try:
+        result = await populate_example_data()
+
+        print("\n" + "=" * 60)
+        print("EXAMPLE DATA POPULATED SUCCESSFULLY")
+        print("=" * 60)
+        print("\nUse these IDs in your workflow examples:")
+        print()
+        for key, value in result.items():
+            print(f"{key}: {value}")
+        print()
+        print("You can now run workflows using these real data IDs!")
+        print("=" * 60)
+
+        return result
+
+    except Exception as e:
+        logger.error(f"Failed to populate example data: {e}", exc_info=True)
+        raise
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/julee_example/repositories/minio/tests/test_document.py
+++ b/julee_example/repositories/minio/tests/test_document.py
@@ -318,7 +318,7 @@ class TestMinioDocumentRepositoryGet:
     async def test_get_document_with_missing_content(
         self, repository: MinioDocumentRepository
     ) -> None:
-        """Test handling document with metadata but missing content."""
+        """Test that missing content returns None."""
         # Store metadata but not content
         metadata_json = (
             '{"document_id": "test-123", "content_multihash": "missing_hash",'
@@ -338,13 +338,8 @@ class TestMinioDocumentRepositoryGet:
         # Act
         result = await repository.get("test-123")
 
-        # Assert - should return document with empty content stream
-        assert result is not None
-        assert result.document_id == "test-123"
-        # Content stream should be empty but present
-        assert result.content is not None
-        content_data = result.content.read()
-        assert content_data == b""
+        # Assert - should return None when content is missing
+        assert result is None
 
     async def test_get_nonexistent_document(
         self, repository: MinioDocumentRepository

--- a/julee_example/worker.py
+++ b/julee_example/worker.py
@@ -11,7 +11,7 @@ import os
 from temporalio.client import Client
 from temporalio.service import RPCError
 from temporalio.worker import Worker
-from temporalio.contrib.pydantic import pydantic_data_converter
+from util.repos.temporal.data_converter import temporal_data_converter
 
 from julee_example.workflows import (
     ExtractAssembleWorkflow,
@@ -76,7 +76,7 @@ async def get_temporal_client_with_retries(
             # 'default' namespace
             client = await Client.connect(
                 endpoint,
-                data_converter=pydantic_data_converter,
+                data_converter=temporal_data_converter,
                 namespace="default",
             )
             logger.info(

--- a/util/repos/temporal/data_converter.py
+++ b/util/repos/temporal/data_converter.py
@@ -1,0 +1,131 @@
+"""
+Custom Temporal data converter with support for temporal_validation context.
+
+This module provides a custom Pydantic data converter that automatically
+adds temporal_validation=True context when deserializing Pydantic models.
+This allows domain models to implement context-aware validation that can
+be more permissive during Temporal serialization/deserialization.
+"""
+
+from typing import Any, Optional, Type
+
+from pydantic import TypeAdapter
+from temporalio.contrib.pydantic import (
+    PydanticJSONPlainPayloadConverter,
+    ToJsonOptions,
+)
+from temporalio.converter import (
+    DataConverter,
+    CompositePayloadConverter,
+    DefaultPayloadConverter,
+    JSONPlainPayloadConverter,
+)
+import temporalio.api.common.v1
+
+
+class TemporalValidationPydanticConverter(PydanticJSONPlainPayloadConverter):
+    """Custom Pydantic JSON converter that adds temporal_validation context.
+
+    This converter extends the standard PydanticJSONPlainPayloadConverter
+    to automatically add temporal_validation=True context when deserializing
+    Pydantic models. This allows domain models to implement more permissive
+    validation during Temporal operations while maintaining strict validation
+    for direct instantiation.
+    """
+
+    def from_payload(
+        self,
+        payload: temporalio.api.common.v1.Payload,
+        type_hint: Optional[Type] = None,
+    ) -> Any:
+        """Deserialize payload with temporal_validation context.
+
+        This method overrides the base implementation to always add
+        temporal_validation=True to the validation context. This allows
+        Pydantic models to detect when they're being deserialized by
+        Temporal and apply appropriate validation rules.
+
+        Args:
+            payload: The Temporal payload to deserialize
+            type_hint: Optional type hint for the expected return type
+
+        Returns:
+            Deserialized object with temporal validation context applied
+        """
+        # Convert Optional[Type] to Type, defaulting to Any (same as original)
+        _type_hint = type_hint if type_hint is not None else Any
+
+        # Always add temporal_validation context for Pydantic model validation
+        return TypeAdapter(_type_hint).validate_json(
+            payload.data, context={"temporal_validation": True}
+        )
+
+
+class TemporalValidationPayloadConverter(CompositePayloadConverter):
+    """Custom payload converter that uses temporal validation context.
+
+    This payload converter extends CompositePayloadConverter to use our
+    custom TemporalValidationPydanticConverter for JSON serialization,
+    ensuring all Pydantic models get temporal_validation context.
+    """
+
+    def __init__(
+        self, to_json_options: Optional[ToJsonOptions] = None
+    ) -> None:
+        """Initialize with custom JSON converter adding temporal context."""
+        # Create our custom JSON converter with temporal validation
+        json_payload_converter = TemporalValidationPydanticConverter(
+            to_json_options
+        )
+
+        # Initialize CompositePayloadConverter, replacing JSON converter
+
+        super().__init__(
+            *(
+                (
+                    c
+                    if not isinstance(c, JSONPlainPayloadConverter)
+                    else json_payload_converter
+                )
+                for c in (
+                    DefaultPayloadConverter.default_encoding_payload_converters
+                )
+            )
+        )
+
+
+def create_temporal_data_converter(
+    to_json_options: Optional[ToJsonOptions] = None,
+) -> DataConverter:
+    """Create a data converter with temporal validation support.
+
+    This factory function creates a DataConverter that uses our custom
+    TemporalValidationPayloadConverter for serialization. This
+    ensures that all Pydantic models are deserialized with the
+    temporal_validation context.
+
+    Args:
+        to_json_options: Optional configuration for JSON serialization
+
+    Returns:
+        DataConverter configured with temporal validation support
+    """
+    return DataConverter(
+        payload_converter_class=TemporalValidationPayloadConverter
+    )
+
+
+# Default temporal data converter with validation context support
+temporal_data_converter = create_temporal_data_converter()
+"""Default Temporal data converter with temporal_validation context support.
+
+This data converter automatically adds temporal_validation=True context
+when deserializing Pydantic models, allowing domain models to implement
+context-aware validation rules.
+
+Usage:
+    client = Client(
+        data_converter=temporal_data_converter,
+        ...
+    )
+"""

--- a/util/repos/temporal/decorators.py
+++ b/util/repos/temporal/decorators.py
@@ -439,7 +439,10 @@ def temporal_workflow_proxy(
                     result = raw_result
                     if needs_validation and raw_result is not None:
                         if hasattr(inner_type, "model_validate"):
-                            result = inner_type.model_validate(raw_result)
+                            result = inner_type.model_validate(
+                                raw_result,
+                                context={"temporal_validation": True},
+                            )
                         else:
                             # For other types, just return as-is
                             result = raw_result
@@ -448,7 +451,9 @@ def temporal_workflow_proxy(
                         and raw_result is not None
                         and hasattr(inner_type, "model_validate")
                     ):
-                        result = inner_type.model_validate(raw_result)
+                        result = inner_type.model_validate(
+                            raw_result, context={"temporal_validation": True}
+                        )
 
                     # Log completion
                     logger.debug(


### PR DESCRIPTION
Follows #62

Also updates the existing non-temporal workflows to match current code.

Note: the examples no longer work due to the validation change we made (document domain model can't have both empty content and content_string) which breaks the temporal serialisation, so I will after all have another PR that fixes that (as it turns out to be a bit more than a single-line fix).