### PR TITLE
Allow temporal serialization of Document to not have content.

### DIFF
--- a/julee_example/domain/document/tests/test_document.py
+++ b/julee_example/domain/document/tests/test_document.py
@@ -274,3 +274,28 @@ class TestDocumentContentValidation:
 
         assert doc.content is None
         assert doc.content_string == content_string
+
+    def test_document_deserialization_with_empty_content_succeeds(
+        self,
+    ) -> None:
+        """Test Temporal deserialization allows empty content."""
+        # This simulates what happens when a Document comes back from Temporal
+        # activities - the ContentStream is excluded from serialization
+        document_data = {
+            "document_id": "test-temporal",
+            "original_filename": "temporal.json",
+            "content_type": "application/json",
+            "size_bytes": 100,
+            "content_multihash": "test_hash",
+            "content": None,
+            "content_string": None,
+        }
+
+        # Should succeed with temporal_validation context
+        doc = Document.model_validate(
+            document_data, context={"temporal_validation": True}
+        )
+
+        assert doc.document_id == "test-temporal"
+        assert doc.content is None
+        assert doc.content_string is None

--- a/julee_example/examples/client_example.py
+++ b/julee_example/examples/client_example.py
@@ -11,7 +11,7 @@ import logging
 import os
 from typing import Optional
 from temporalio.client import Client
-from temporalio.contrib.pydantic import pydantic_data_converter
+from util.repos.temporal.data_converter import temporal_data_converter
 from minio import Minio
 
 from julee_example.workflows import (
@@ -49,7 +49,7 @@ async def start_extract_assemble_workflow(
     # Connect to Temporal
     client = await Client.connect(
         temporal_endpoint,
-        data_converter=pydantic_data_converter,
+        data_converter=temporal_data_converter,
         namespace="default",
     )
 
@@ -107,7 +107,7 @@ async def wait_for_workflow_result(
     # Connect to Temporal
     client = await Client.connect(
         temporal_endpoint,
-        data_converter=pydantic_data_converter,
+        data_converter=temporal_data_converter,
         namespace="default",
     )
 
@@ -185,7 +185,7 @@ async def query_workflow_status(
     # Connect to Temporal
     client = await Client.connect(
         temporal_endpoint,
-        data_converter=pydantic_data_converter,
+        data_converter=temporal_data_converter,
         namespace="default",
     )
 
@@ -238,7 +238,7 @@ async def cancel_workflow(
     # Connect to Temporal
     client = await Client.connect(
         temporal_endpoint,
-        data_converter=pydantic_data_converter,
+        data_converter=temporal_data_converter,
         namespace="default",
     )
 

--- a/julee_example/repositories/minio/tests/test_document.py
+++ b/julee_example/repositories/minio/tests/test_document.py
@@ -318,7 +318,7 @@ class TestMinioDocumentRepositoryGet:
     async def test_get_document_with_missing_content(
         self, repository: MinioDocumentRepository
     ) -> None:
-        """Test handling document with metadata but missing content."""
+        """Test that missing content returns None."""
         # Store metadata but not content
         metadata_json = (
             '{"document_id": "test-123", "content_multihash": "missing_hash",'
@@ -338,13 +338,8 @@ class TestMinioDocumentRepositoryGet:
         # Act
         result = await repository.get("test-123")
 
-        # Assert - should return document with empty content stream
-        assert result is not None
-        assert result.document_id == "test-123"
-        # Content stream should be empty but present
-        assert result.content is not None
-        content_data = result.content.read()
-        assert content_data == b""
+        # Assert - should return None when content is missing
+        assert result is None
 
     async def test_get_nonexistent_document(
         self, repository: MinioDocumentRepository

--- a/julee_example/worker.py
+++ b/julee_example/worker.py
@@ -11,7 +11,7 @@ import os
 from temporalio.client import Client
 from temporalio.service import RPCError
 from temporalio.worker import Worker
-from temporalio.contrib.pydantic import pydantic_data_converter
+from util.repos.temporal.data_converter import temporal_data_converter
 
 from julee_example.workflows import (
     ExtractAssembleWorkflow,
@@ -76,7 +76,7 @@ async def get_temporal_client_with_retries(
             # 'default' namespace
             client = await Client.connect(
                 endpoint,
-                data_converter=pydantic_data_converter,
+                data_converter=temporal_data_converter,
                 namespace="default",
             )
             logger.info(

--- a/util/repos/temporal/data_converter.py
+++ b/util/repos/temporal/data_converter.py
@@ -1,0 +1,131 @@
+"""
+Custom Temporal data converter with support for temporal_validation context.
+
+This module provides a custom Pydantic data converter that automatically
+adds temporal_validation=True context when deserializing Pydantic models.
+This allows domain models to implement context-aware validation that can
+be more permissive during Temporal serialization/deserialization.
+"""
+
+from typing import Any, Optional, Type
+
+from pydantic import TypeAdapter
+from temporalio.contrib.pydantic import (
+    PydanticJSONPlainPayloadConverter,
+    ToJsonOptions,
+)
+from temporalio.converter import (
+    DataConverter,
+    CompositePayloadConverter,
+    DefaultPayloadConverter,
+    JSONPlainPayloadConverter,
+)
+import temporalio.api.common.v1
+
+
+class TemporalValidationPydanticConverter(PydanticJSONPlainPayloadConverter):
+    """Custom Pydantic JSON converter that adds temporal_validation context.
+
+    This converter extends the standard PydanticJSONPlainPayloadConverter
+    to automatically add temporal_validation=True context when deserializing
+    Pydantic models. This allows domain models to implement more permissive
+    validation during Temporal operations while maintaining strict validation
+    for direct instantiation.
+    """
+
+    def from_payload(
+        self,
+        payload: temporalio.api.common.v1.Payload,
+        type_hint: Optional[Type] = None,
+    ) -> Any:
+        """Deserialize payload with temporal_validation context.
+
+        This method overrides the base implementation to always add
+        temporal_validation=True to the validation context. This allows
+        Pydantic models to detect when they're being deserialized by
+        Temporal and apply appropriate validation rules.
+
+        Args:
+            payload: The Temporal payload to deserialize
+            type_hint: Optional type hint for the expected return type
+
+        Returns:
+            Deserialized object with temporal validation context applied
+        """
+        # Convert Optional[Type] to Type, defaulting to Any (same as original)
+        _type_hint = type_hint if type_hint is not None else Any
+
+        # Always add temporal_validation context for Pydantic model validation
+        return TypeAdapter(_type_hint).validate_json(
+            payload.data, context={"temporal_validation": True}
+        )
+
+
+class TemporalValidationPayloadConverter(CompositePayloadConverter):
+    """Custom payload converter that uses temporal validation context.
+
+    This payload converter extends CompositePayloadConverter to use our
+    custom TemporalValidationPydanticConverter for JSON serialization,
+    ensuring all Pydantic models get temporal_validation context.
+    """
+
+    def __init__(
+        self, to_json_options: Optional[ToJsonOptions] = None
+    ) -> None:
+        """Initialize with custom JSON converter adding temporal context."""
+        # Create our custom JSON converter with temporal validation
+        json_payload_converter = TemporalValidationPydanticConverter(
+            to_json_options
+        )
+
+        # Initialize CompositePayloadConverter, replacing JSON converter
+
+        super().__init__(
+            *(
+                (
+                    c
+                    if not isinstance(c, JSONPlainPayloadConverter)
+                    else json_payload_converter
+                )
+                for c in (
+                    DefaultPayloadConverter.default_encoding_payload_converters
+                )
+            )
+        )
+
+
+def create_temporal_data_converter(
+    to_json_options: Optional[ToJsonOptions] = None,
+) -> DataConverter:
+    """Create a data converter with temporal validation support.
+
+    This factory function creates a DataConverter that uses our custom
+    TemporalValidationPayloadConverter for serialization. This
+    ensures that all Pydantic models are deserialized with the
+    temporal_validation context.
+
+    Args:
+        to_json_options: Optional configuration for JSON serialization
+
+    Returns:
+        DataConverter configured with temporal validation support
+    """
+    return DataConverter(
+        payload_converter_class=TemporalValidationPayloadConverter
+    )
+
+
+# Default temporal data converter with validation context support
+temporal_data_converter = create_temporal_data_converter()
+"""Default Temporal data converter with temporal_validation context support.
+
+This data converter automatically adds temporal_validation=True context
+when deserializing Pydantic models, allowing domain models to implement
+context-aware validation rules.
+
+Usage:
+    client = Client(
+        data_converter=temporal_data_converter,
+        ...
+    )
+"""

--- a/util/repos/temporal/decorators.py
+++ b/util/repos/temporal/decorators.py
@@ -439,7 +439,10 @@ def temporal_workflow_proxy(
                     result = raw_result
                     if needs_validation and raw_result is not None:
                         if hasattr(inner_type, "model_validate"):
-                            result = inner_type.model_validate(raw_result)
+                            result = inner_type.model_validate(
+                                raw_result,
+                                context={"temporal_validation": True},
+                            )
                         else:
                             # For other types, just return as-is
                             result = raw_result
@@ -448,7 +451,9 @@ def temporal_workflow_proxy(
                         and raw_result is not None
                         and hasattr(inner_type, "model_validate")
                     ):
-                        result = inner_type.model_validate(raw_result)
+                        result = inner_type.model_validate(
+                            raw_result, context={"temporal_validation": True}
+                        )
 
                     # Log completion
                     logger.debug(


### PR DESCRIPTION
Follows #63 , which added the new example worker and client script, but it failed to run due to the new domain validation we added on Document, that either the `content` (stream) or `content_string` is set. While that makes perfect sense when *creating* a Document, it does not when temporal is serialising a document. For example, if we create the document with a `content` (a stream), we save it - (stream gets saved to the `documet-content` bucket using content-addressable hash), then temporal serialises it to send over the wire... when it does so, it should *not* have either set.

So the fix here is using our own modified data converter, which just adds a bit of context which the domain model can check for, so it allows the empty content when deserialising from temporal.