### PR TITLE
Add `get_many` to the base repository interface and impl.

### DIFF
--- a/julee_example/repositories/base.py
+++ b/julee_example/repositories/base.py
@@ -23,7 +23,7 @@ In Temporal workflow contexts, these protocols are implemented by workflow
 stubs that delegate to activities for durability and proper error handling.
 """
 
-from typing import Protocol, Optional, runtime_checkable, TypeVar
+from typing import Protocol, Optional, runtime_checkable, TypeVar, List, Dict
 from pydantic import BaseModel
 
 # Type variable bound to Pydantic BaseModel for domain entities
@@ -55,6 +55,30 @@ class BaseRepository(Protocol[T]):
         - Must be idempotent: multiple calls return same result
         - Should handle missing entities gracefully (return None)
         - Loads complete entity with all relationships
+        """
+        ...
+
+    async def get_many(self, entity_ids: List[str]) -> Dict[str, Optional[T]]:
+        """Retrieve multiple entities by ID.
+
+        Args:
+            entity_ids: List of unique entity identifiers
+
+        Returns:
+            Dict mapping entity_id to entity (or None if not found)
+
+        Implementation Notes:
+        - Must be idempotent: multiple calls return same result
+        - Should handle missing entities gracefully (return None for missing)
+        - Implementations may optimize with batch operations or fall back
+          to individual get() calls
+        - Keys in returned dict correspond exactly to input entity_ids
+        - Missing entities have None values in the returned dict
+
+        Workflow Context:
+        In Temporal workflows, this method is implemented as an activity
+        to ensure batch operations are durably stored and consistent
+        across workflow replays.
         """
         ...
 

--- a/julee_example/repositories/memory/assembly.py
+++ b/julee_example/repositories/memory/assembly.py
@@ -12,7 +12,7 @@ All operations are still async to maintain interface compatibility.
 """
 
 import logging
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 
 from julee_example.domain import Assembly
 from julee_example.repositories.assembly import AssemblyRepository
@@ -66,6 +66,19 @@ class MemoryAssemblyRepository(
             Unique assembly ID string
         """
         return self.generate_entity_id("assembly")
+
+    async def get_many(
+        self, assembly_ids: List[str]
+    ) -> Dict[str, Optional[Assembly]]:
+        """Retrieve multiple assemblies by ID.
+
+        Args:
+            assembly_ids: List of unique assembly identifiers
+
+        Returns:
+            Dict mapping assembly_id to Assembly (or None if not found)
+        """
+        return self.get_many_entities(assembly_ids)
 
     def _add_entity_specific_log_data(
         self, entity: Assembly, log_data: Dict[str, Any]

--- a/julee_example/repositories/memory/assembly_specification.py
+++ b/julee_example/repositories/memory/assembly_specification.py
@@ -14,7 +14,7 @@ avoided. All operations are still async to maintain interface compatibility.
 """
 
 import logging
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 
 from julee_example.domain import AssemblySpecification
 from julee_example.repositories.assembly_specification import (
@@ -79,6 +79,21 @@ class MemoryAssemblySpecificationRepository(
             Unique assembly specification ID string
         """
         return self.generate_entity_id("spec")
+
+    async def get_many(
+        self, assembly_specification_ids: List[str]
+    ) -> Dict[str, Optional[AssemblySpecification]]:
+        """Retrieve multiple assembly specifications by ID.
+
+        Args:
+            assembly_specification_ids: List of unique specification
+            identifiers
+
+        Returns:
+            Dict mapping specification_id to AssemblySpecification (or None if
+            not found)
+        """
+        return self.get_many_entities(assembly_specification_ids)
 
     def _add_entity_specific_log_data(
         self, entity: AssemblySpecification, log_data: Dict[str, Any]

--- a/julee_example/repositories/memory/document.py
+++ b/julee_example/repositories/memory/document.py
@@ -14,7 +14,7 @@ All operations are still async to maintain interface compatibility.
 import hashlib
 import io
 import logging
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 
 from julee_example.domain import Document, ContentStream
 from julee_example.repositories.document import DocumentRepository
@@ -109,6 +109,19 @@ class MemoryDocumentRepository(
             Unique document ID string
         """
         return self.generate_entity_id("doc")
+
+    async def get_many(
+        self, document_ids: List[str]
+    ) -> Dict[str, Optional[Document]]:
+        """Retrieve multiple documents by ID.
+
+        Args:
+            document_ids: List of unique document identifiers
+
+        Returns:
+            Dict mapping document_id to Document (or None if not found)
+        """
+        return self.get_many_entities(document_ids)
 
     def _add_entity_specific_log_data(
         self, entity: Document, log_data: Dict[str, Any]

--- a/julee_example/repositories/memory/document_policy_validation.py
+++ b/julee_example/repositories/memory/document_policy_validation.py
@@ -13,7 +13,7 @@ All operations are still async to maintain interface compatibility.
 """
 
 import logging
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 
 from julee_example.domain.policy import DocumentPolicyValidation
 from julee_example.repositories.document_policy_validation import (
@@ -73,6 +73,20 @@ class MemoryDocumentPolicyValidationRepository(
             Unique validation ID string
         """
         return self.generate_entity_id("validation")
+
+    async def get_many(
+        self, validation_ids: List[str]
+    ) -> Dict[str, Optional[DocumentPolicyValidation]]:
+        """Retrieve multiple document policy validations by ID.
+
+        Args:
+            validation_ids: List of unique validation identifiers
+
+        Returns:
+            Dict mapping validation_id to DocumentPolicyValidation (or None if
+            not found)
+        """
+        return self.get_many_entities(validation_ids)
 
     def _add_entity_specific_log_data(
         self, entity: DocumentPolicyValidation, log_data: Dict[str, Any]

--- a/julee_example/repositories/memory/knowledge_service_config.py
+++ b/julee_example/repositories/memory/knowledge_service_config.py
@@ -14,7 +14,7 @@ interface compatibility.
 """
 
 import logging
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 
 from julee_example.domain import KnowledgeServiceConfig
 from julee_example.repositories.knowledge_service_config import (
@@ -77,6 +77,21 @@ class MemoryKnowledgeServiceConfigRepository(
             Unique knowledge service ID string
         """
         return self.generate_entity_id("ks")
+
+    async def get_many(
+        self, knowledge_service_ids: List[str]
+    ) -> Dict[str, Optional[KnowledgeServiceConfig]]:
+        """Retrieve multiple knowledge service configs by ID.
+
+        Args:
+            knowledge_service_ids: List of unique knowledge service
+            identifiers
+
+        Returns:
+            Dict mapping knowledge_service_id to KnowledgeServiceConfig (or
+            None if not found)
+        """
+        return self.get_many_entities(knowledge_service_ids)
 
     def _add_entity_specific_log_data(
         self, entity: KnowledgeServiceConfig, log_data: Dict[str, Any]

--- a/julee_example/repositories/memory/knowledge_service_query.py
+++ b/julee_example/repositories/memory/knowledge_service_query.py
@@ -13,7 +13,7 @@ should be avoided.
 """
 
 import logging
-from typing import Dict, Optional, Any
+from typing import Dict, Optional, Any, List
 
 from julee_example.domain.assembly_specification import KnowledgeServiceQuery
 from julee_example.repositories.knowledge_service_query import (
@@ -66,6 +66,20 @@ class MemoryKnowledgeServiceQueryRepository(
             query: KnowledgeServiceQuery object to store
         """
         self.save_entity(query, "query_id")
+
+    async def get_many(
+        self, query_ids: List[str]
+    ) -> Dict[str, Optional[KnowledgeServiceQuery]]:
+        """Retrieve multiple knowledge service queries by ID.
+
+        Args:
+            query_ids: List of unique query identifiers
+
+        Returns:
+            Dict mapping query_id to KnowledgeServiceQuery (or None if not
+            found)
+        """
+        return self.get_many_entities(query_ids)
 
     async def generate_id(self) -> str:
         """Generate a unique query identifier.

--- a/julee_example/repositories/memory/policy.py
+++ b/julee_example/repositories/memory/policy.py
@@ -12,7 +12,7 @@ All operations are still async to maintain interface compatibility.
 """
 
 import logging
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 
 from julee_example.domain import Policy
 from julee_example.repositories.policy import PolicyRepository
@@ -64,6 +64,19 @@ class MemoryPolicyRepository(PolicyRepository, MemoryRepositoryMixin[Policy]):
             Unique policy ID string
         """
         return self.generate_entity_id("policy")
+
+    async def get_many(
+        self, policy_ids: List[str]
+    ) -> Dict[str, Optional[Policy]]:
+        """Retrieve multiple policies by ID.
+
+        Args:
+            policy_ids: List of unique policy identifiers
+
+        Returns:
+            Dict mapping policy_id to Policy (or None if not found)
+        """
+        return self.get_many_entities(policy_ids)
 
     def _add_entity_specific_log_data(
         self, entity: Policy, log_data: Dict[str, Any]

--- a/julee_example/repositories/minio/assembly.py
+++ b/julee_example/repositories/minio/assembly.py
@@ -11,7 +11,7 @@ the large payload handling pattern from the architectural guidelines.
 """
 
 import logging
-from typing import Optional
+from typing import Optional, List, Dict
 
 from julee_example.domain import Assembly
 from julee_example.repositories.assembly import AssemblyRepository
@@ -68,6 +68,37 @@ class MinioAssemblyRepository(AssemblyRepository, MinioRepositoryMixin):
                 "assembled_document_id": assembly.assembled_document_id,
             },
         )
+
+    async def get_many(
+        self, assembly_ids: List[str]
+    ) -> Dict[str, Optional[Assembly]]:
+        """Retrieve multiple assemblies by ID.
+
+        Args:
+            assembly_ids: List of unique assembly identifiers
+
+        Returns:
+            Dict mapping assembly_id to Assembly (or None if not found)
+        """
+        # Convert assembly IDs to object names (direct mapping in this case)
+        object_names = assembly_ids
+
+        # Get objects from Minio using batch method
+        object_results = self.get_many_json_objects(
+            bucket_name=self.assembly_bucket,
+            object_names=object_names,
+            model_class=Assembly,
+            not_found_log_message="Assembly not found",
+            error_log_message="Error retrieving assembly",
+            extra_log_data={"assembly_ids": assembly_ids},
+        )
+
+        # Convert object names back to assembly IDs for the result
+        result: Dict[str, Optional[Assembly]] = {}
+        for assembly_id in assembly_ids:
+            result[assembly_id] = object_results[assembly_id]
+
+        return result
 
     async def generate_id(self) -> str:
         """Generate a unique assembly identifier."""

--- a/julee_example/repositories/minio/document.py
+++ b/julee_example/repositories/minio/document.py
@@ -16,7 +16,7 @@ import json
 import hashlib
 import logging
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Optional, List, Dict
 
 from minio.error import S3Error  # type: ignore[import-untyped]
 import multihash  # type: ignore[import-untyped]
@@ -24,6 +24,13 @@ import multihash  # type: ignore[import-untyped]
 from julee_example.domain import Document, ContentStream
 from julee_example.repositories.document import DocumentRepository
 from .client import MinioClient, MinioRepositoryMixin
+from pydantic import BaseModel, ConfigDict
+
+
+class RawMetadata(BaseModel):
+    """Simple wrapper for raw document metadata JSON."""
+
+    model_config = ConfigDict(extra="allow")  # Allow arbitrary fields
 
 
 class MinioDocumentRepository(DocumentRepository, MinioRepositoryMixin):
@@ -223,6 +230,113 @@ class MinioDocumentRepository(DocumentRepository, MinioRepositoryMixin):
                 exc_info=True,
             )
             raise
+
+    async def get_many(
+        self, document_ids: List[str]
+    ) -> Dict[str, Optional[Document]]:
+        """Retrieve multiple documents by ID using batch operations.
+
+        Args:
+            document_ids: List of unique document identifiers
+
+        Returns:
+            Dict mapping document_id to Document (or None if not found)
+
+        Note:
+            This implementation optimizes by batch-fetching metadata first,
+            then batch-fetching unique content streams, then splicing them
+            together.
+        """
+        if not document_ids:
+            return {}
+
+        self.logger.debug(
+            "MinioDocumentRepository: Attempting to retrieve multiple docs",
+            extra={
+                "document_ids": document_ids,
+                "count": len(document_ids),
+                "metadata_bucket": self.metadata_bucket,
+            },
+        )
+
+        # Step 1: Batch retrieve metadata for all documents
+        raw_metadata_results = self.get_many_json_objects(
+            bucket_name=self.metadata_bucket,
+            object_names=document_ids,  # Direct mapping for metadata
+            model_class=RawMetadata,
+            not_found_log_message="Document metadata not found",
+            error_log_message="Error retrieving document metadata",
+            extra_log_data={"document_ids": document_ids},
+        )
+
+        # Convert to dict format
+        metadata_results: Dict[str, Optional[dict]] = {}
+        for document_id, raw_metadata in raw_metadata_results.items():
+            if raw_metadata:
+                metadata_results[document_id] = raw_metadata.model_dump()
+            else:
+                metadata_results[document_id] = None
+
+        # Step 2: Extract unique content multihashes from found metadata
+        content_hashes = set()
+        for metadata_dict in metadata_results.values():
+            if metadata_dict and metadata_dict.get("content_multihash"):
+                content_hashes.add(metadata_dict["content_multihash"])
+
+        # Step 3: Batch retrieve content streams for unique hashes
+        content_results = {}
+        if content_hashes:
+            content_results = self.get_many_binary_objects(
+                bucket_name=self.content_bucket,
+                object_names=list(content_hashes),
+                not_found_log_message="Content not found",
+                error_log_message="Error retrieving content",
+                extra_log_data={
+                    "document_ids": document_ids,
+                    "unique_content_hashes": len(content_hashes),
+                },
+            )
+
+        # Step 4: Splice metadata and content together into Documents
+        result: Dict[str, Optional[Document]] = {}
+        for document_id in document_ids:
+            metadata_dict = metadata_results.get(document_id)
+            if not metadata_dict:
+                result[document_id] = None
+                continue
+
+            # Get content stream using multihash
+            content_multihash = metadata_dict.get("content_multihash")
+            if content_multihash and content_multihash in content_results:
+                content_stream = content_results[content_multihash]
+                metadata_dict["content"] = content_stream
+            else:
+                metadata_dict["content"] = None
+
+            try:
+                result[document_id] = Document(**metadata_dict)
+            except Exception as e:
+                self.logger.error(
+                    "Failed to create Document from metadata",
+                    extra={
+                        "document_id": document_id,
+                        "error": str(e),
+                    },
+                )
+                result[document_id] = None
+
+        found_count = sum(1 for doc in result.values() if doc is not None)
+        self.logger.info(
+            f"Retrieved {found_count}/{len(document_ids)} documents",
+            extra={
+                "requested_count": len(document_ids),
+                "found_count": found_count,
+                "missing_count": len(document_ids) - found_count,
+                "unique_content_fetched": len(content_hashes),
+            },
+        )
+
+        return result
 
     async def generate_id(self) -> str:
         """Generate a unique document identifier."""

--- a/julee_example/use_cases/extract_assemble_data.py
+++ b/julee_example/use_cases/extract_assemble_data.py
@@ -287,14 +287,18 @@ class ExtractAssembleDataUseCase:
         self, assembly_specification: AssemblySpecification
     ) -> Dict[str, KnowledgeServiceQuery]:
         """Retrieve all knowledge service queries needed for this assembly."""
-        # TODO: we should update the interface to take multiple ids (for all
-        # repositories), since most backends will support fetching multiple.
+        query_ids = list(
+            assembly_specification.knowledge_service_queries.values()
+        )
+
+        # Use batch retrieval for efficiency
+        query_results = await self.knowledge_service_query_repo.get_many(
+            query_ids
+        )
 
         queries = {}
-        for (
-            query_id
-        ) in assembly_specification.knowledge_service_queries.values():
-            query = await self.knowledge_service_query_repo.get(query_id)
+        for query_id in query_ids:
+            query = query_results.get(query_id)
             if not query:
                 raise ValueError(
                     f"Knowledge service query not found: {query_id}"


### PR DESCRIPTION
Fixes another TODO I had.

We don't have to land this now if you're generating docs, but the aim is to allow implementations to be more efficient when they can (getting multiple entities at once). MinIO/S3 doesn't allow it, but postgres for example would. So it makes sense for the interface to include it.

Note: I need to fix a CI issue with the previous branch which this one is based on anyway.