### PR TITLE
Update to be compatible with minio 7.2.18

### DIFF
--- a/julee_example/repositories/minio/client.py
+++ b/julee_example/repositories/minio/client.py
@@ -23,9 +23,11 @@ from typing import (
     List,
     Union,
     TypeVar,
+    BinaryIO,
 )
-from urllib3.response import HTTPResponse
+from urllib3.response import BaseHTTPResponse
 from minio.datatypes import Object
+from minio.api import ObjectWriteResult
 from minio.error import S3Error  # type: ignore[import-untyped]
 from pydantic import BaseModel
 
@@ -68,11 +70,13 @@ class MinioClient(Protocol):
         self,
         bucket_name: str,
         object_name: str,
-        data: Any,
+        data: BinaryIO,
         length: int,
         content_type: str = "application/octet-stream",
-        metadata: Optional[Dict[str, str]] = None,
-    ) -> Any:
+        metadata: Optional[
+            Dict[str, Union[str, List[str], tuple[str]]]
+        ] = None,
+    ) -> ObjectWriteResult:
         """Store an object in the bucket.
 
         Args:
@@ -91,7 +95,9 @@ class MinioClient(Protocol):
         """
         ...
 
-    def get_object(self, bucket_name: str, object_name: str) -> HTTPResponse:
+    def get_object(
+        self, bucket_name: str, object_name: str
+    ) -> BaseHTTPResponse:
         """Retrieve an object from the bucket.
 
         Args:

--- a/julee_example/repositories/minio/tests/test_document.py
+++ b/julee_example/repositories/minio/tests/test_document.py
@@ -11,6 +11,7 @@ import pytest
 import hashlib
 import multihash
 from typing import Any
+from unittest.mock import Mock
 from minio.error import S3Error
 
 
@@ -104,12 +105,12 @@ class TestMinioDocumentRepositoryInitialization:
         def failing_make_bucket(bucket_name: str) -> None:
             if bucket_name == "documents-content":
                 raise S3Error(
-                    "AccessDenied",
-                    "Access denied",
-                    "AccessDenied",
-                    "req123",
-                    "host123",
-                    None,
+                    code="AccessDenied",
+                    message="Access denied",
+                    resource="AccessDenied",
+                    request_id="req123",
+                    host_id="host123",
+                    response=Mock(),
                 )
             return original_make_bucket(bucket_name)
 
@@ -240,12 +241,12 @@ class TestMinioDocumentRepositoryStore:
         ) -> Any:
             if bucket_name == "documents-content":
                 raise S3Error(
-                    "AccessDenied",
-                    "Access denied",
-                    "AccessDenied",
-                    "req123",
-                    "host123",
-                    None,
+                    code="AccessDenied",
+                    message="Access denied",
+                    resource="AccessDenied",
+                    request_id="req123",
+                    host_id="host123",
+                    response=Mock(),
                 )
             return original_put_object(
                 bucket_name, object_name, data, length, **kwargs
@@ -563,12 +564,12 @@ class TestMinioDocumentRepositoryErrorHandling:
         ) -> Any:
             if bucket_name == "documents":
                 raise S3Error(
-                    "AccessDenied",
-                    "Access denied",
-                    "AccessDenied",
-                    "req123",
-                    "host123",
-                    None,
+                    code="AccessDenied",
+                    message="Access denied",
+                    resource="AccessDenied",
+                    request_id="req123",
+                    host_id="host123",
+                    response=Mock(),
                 )
             return original_put_object(
                 bucket_name, object_name, data, length, **kwargs

--- a/util/repos/minio/file_storage.py
+++ b/util/repos/minio/file_storage.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import os
 from typing import Optional
@@ -25,18 +26,26 @@ class MinioFileStorageRepository(FileStorageRepository):
         secure: bool = False,
         bucket_name: Optional[str] = None,
     ):
-        self._endpoint = endpoint or os.environ.get(
-            "MINIO_ENDPOINT", "localhost:9000"
+        self._endpoint = (
+            endpoint
+            if endpoint is not None
+            else os.environ.get("MINIO_ENDPOINT", "localhost:9000")
         )
-        self._access_key = access_key or os.environ.get(
-            "MINIO_ROOT_USER", "minioadmin"
+        self._access_key = (
+            access_key
+            if access_key is not None
+            else os.environ.get("MINIO_ROOT_USER", "minioadmin")
         )
-        self._secret_key = secret_key or os.environ.get(
-            "MINIO_ROOT_PASSWORD", "minioadmin"
+        self._secret_key = (
+            secret_key
+            if secret_key is not None
+            else os.environ.get("MINIO_ROOT_PASSWORD", "minioadmin")
         )
         self._secure = secure
-        self._bucket_name = bucket_name or os.environ.get(
-            "MINIO_BUCKET_NAME", "file-storage"
+        self._bucket_name = (
+            bucket_name
+            if bucket_name is not None
+            else os.environ.get("MINIO_BUCKET_NAME", "file-storage")
         )
 
         self._client: Optional[Minio] = None
@@ -102,7 +111,7 @@ class MinioFileStorageRepository(FileStorageRepository):
             client.put_object(
                 self._bucket_name,
                 args.file_id,
-                args.data,
+                io.BytesIO(args.data),
                 len(args.data),
                 content_type=args.content_type,
                 metadata=args.metadata,
@@ -176,8 +185,10 @@ class MinioFileStorageRepository(FileStorageRepository):
             )
             return FileMetadata(
                 file_id=file_id,
-                filename=stat.user_metadata.get(
-                    "X-Amz-Meta-Filename"
+                filename=(
+                    stat.metadata.get("X-Amz-Meta-Filename")
+                    if stat.metadata
+                    else None
                 ),  # Minio prepends X-Amz-Meta-
                 content_type=stat.content_type,
                 size_bytes=stat.size,
@@ -186,9 +197,9 @@ class MinioFileStorageRepository(FileStorageRepository):
                 metadata=(
                     {
                         k.replace("X-Amz-Meta-", ""): v
-                        for k, v in stat.user_metadata.items()
+                        for k, v in stat.metadata.items()
                     }
-                    if stat.user_metadata
+                    if stat.metadata
                     else {}
                 ),
             )


### PR DESCRIPTION
In minio 7.2.18, the `S3Error` exception class was changed from a regular class to a **frozen dataclass**. This caused a `FrozenInstanceError` when Python's exception handling machinery attempted to set the `__traceback__` attribute during exception propagation.

This is causing my other PRs to fail CI, so I'm fixing this separately and then will rebase those to land them.