### PR TITLE
Register new activities in the worker.

### DIFF
--- a/julee_example/repositories/temporal/activities.py
+++ b/julee_example/repositories/temporal/activities.py
@@ -10,7 +10,7 @@ The classes follow the naming pattern documented in systemPatterns.org:
 - Each repository type gets its own activity prefix
 """
 
-from util.repos.temporal.decorators import temporal_activity_registration
+from util.temporal.decorators import temporal_activity_registration
 from julee_example.repositories.minio.assembly import MinioAssemblyRepository
 from julee_example.repositories.minio.assembly_specification import (
     MinioAssemblySpecificationRepository,

--- a/julee_example/repositories/temporal/proxies.py
+++ b/julee_example/repositories/temporal/proxies.py
@@ -11,7 +11,7 @@ workflow.execute_activity() with the appropriate activity names, timeouts,
 and retry policies.
 """
 
-from util.repos.temporal.decorators import temporal_workflow_proxy
+from util.temporal.decorators import temporal_workflow_proxy
 from julee_example.repositories.assembly import AssemblyRepository
 from julee_example.repositories.assembly_specification import (
     AssemblySpecificationRepository,

--- a/julee_example/services/temporal/activities.py
+++ b/julee_example/services/temporal/activities.py
@@ -15,7 +15,7 @@ import io
 import logging
 from typing_extensions import override
 
-from util.repos.temporal.decorators import temporal_activity_registration
+from util.temporal.decorators import temporal_activity_registration
 from julee_example.services.knowledge_service.factory import (
     ConfigurableKnowledgeService,
 )

--- a/julee_example/services/temporal/proxies.py
+++ b/julee_example/services/temporal/proxies.py
@@ -11,7 +11,7 @@ workflow.execute_activity() with the appropriate activity names, timeouts,
 and retry policies.
 """
 
-from util.repos.temporal.decorators import temporal_workflow_proxy
+from util.temporal.decorators import temporal_workflow_proxy
 from julee_example.services.knowledge_service import KnowledgeService
 
 # Import activity name bases from shared module

--- a/julee_example/worker.py
+++ b/julee_example/worker.py
@@ -28,6 +28,7 @@ from julee_example.services.temporal.activities import (
 )
 from minio import Minio
 from julee_example.repositories.minio.client import MinioClient
+from util.temporal.activities import collect_activities_from_instances
 
 logger = logging.getLogger(__name__)
 
@@ -165,34 +166,17 @@ async def run_worker() -> None:
         document_repo=temporal_document_repo
     )
 
-    # Collect all activities from repository instances
-    # The @temporal_activity_registration decorator automatically wraps
-    # all async methods as Temporal activities
-    activities = [
-        # Assembly repository activities
-        temporal_assembly_repo.generate_id,
-        temporal_assembly_repo.save,
-        temporal_assembly_repo.get,
-        # Assembly specification repository activities
-        temporal_assembly_spec_repo.generate_id,
-        temporal_assembly_spec_repo.save,
-        temporal_assembly_spec_repo.get,
-        # Document repository activities
-        temporal_document_repo.generate_id,
-        temporal_document_repo.save,
-        temporal_document_repo.get,
-        # Knowledge service config repository activities
-        temporal_knowledge_config_repo.generate_id,
-        temporal_knowledge_config_repo.save,
-        temporal_knowledge_config_repo.get,
-        # Knowledge service query repository activities
-        temporal_knowledge_query_repo.generate_id,
-        temporal_knowledge_query_repo.save,
-        temporal_knowledge_query_repo.get,
-        # Knowledge service activities
-        temporal_knowledge_service.register_file,
-        temporal_knowledge_service.execute_query,
-    ]
+    # Automatically collect all activities from decorated instances
+    # This uses the same _discover_protocol_methods that the decorator uses,
+    # ensuring we never miss activities and eliminating boilerplate
+    activities = collect_activities_from_instances(
+        temporal_assembly_repo,
+        temporal_assembly_spec_repo,
+        temporal_document_repo,
+        temporal_knowledge_config_repo,
+        temporal_knowledge_query_repo,
+        temporal_knowledge_service,
+    )
 
     logger.info(
         "Creating Temporal worker for julee_example domain",

--- a/sample/repos/temporal/activities.py
+++ b/sample/repos/temporal/activities.py
@@ -10,7 +10,7 @@ The classes follow the naming pattern documented in systemPatterns.org:
 - Each repository type gets its own activity prefix
 """
 
-from util.repos.temporal.decorators import temporal_activity_registration
+from util.temporal.decorators import temporal_activity_registration
 from sample.repos.minio.order import MinioOrderRepository
 from sample.repos.minio.payment import MinioPaymentRepository
 from sample.repos.minio.inventory import MinioInventoryRepository

--- a/sample/repos/temporal/proxies.py
+++ b/sample/repos/temporal/proxies.py
@@ -11,7 +11,7 @@ workflow.execute_activity() with the appropriate activity names, timeouts,
 and retry policies.
 """
 
-from util.repos.temporal.decorators import temporal_workflow_proxy
+from util.temporal.decorators import temporal_workflow_proxy
 from sample.repositories import (
     OrderRepository,
     PaymentRepository,

--- a/sample/tests/test_validation.py
+++ b/sample/tests/test_validation.py
@@ -19,7 +19,7 @@ from sample.validation import (
 from sample.repositories import PaymentRepository, InventoryRepository
 from sample.repos.minio.inventory import MinioInventoryRepository
 from sample.repos.minio.payment import MinioPaymentRepository
-from util.repos.temporal.decorators import temporal_activity_registration
+from util.temporal.decorators import temporal_activity_registration
 from sample.domain import Order, Payment, OrderItem
 
 
@@ -189,7 +189,8 @@ def test_factory_function_metadata() -> None:
         pass
 
     factory = create_validated_repository_factory(
-        PaymentRepository, TestTemporalMinioPaymentRepository  # type: ignore[type-abstract]
+        PaymentRepository,  # type: ignore[type-abstract]
+        TestTemporalMinioPaymentRepository,
     )
 
     assert (

--- a/util/repos/temporal/__init__.py
+++ b/util/repos/temporal/__init__.py
@@ -6,6 +6,6 @@ including the temporal_activity_registration decorator for automatically
 wrapping repository methods as Temporal activities.
 """
 
-from .decorators import temporal_activity_registration
+from util.temporal.decorators import temporal_activity_registration
 
 __all__ = ["temporal_activity_registration"]

--- a/util/repos/temporal/minio_file_storage.py
+++ b/util/repos/temporal/minio_file_storage.py
@@ -1,4 +1,4 @@
-from util.repos.temporal.decorators import temporal_activity_registration
+from util.temporal.decorators import temporal_activity_registration
 from util.repos.minio.file_storage import MinioFileStorageRepository
 
 

--- a/util/temporal/__init__.py
+++ b/util/temporal/__init__.py
@@ -1,0 +1,22 @@
+"""
+Temporal utilities package.
+
+This package provides utility functions and classes for working with
+Temporal workflows and activities.
+"""
+
+from .activities import (
+    collect_activities_from_instances,
+    discover_protocol_methods,
+)
+from .decorators import (
+    temporal_activity_registration,
+    temporal_workflow_proxy,
+)
+
+__all__ = [
+    "collect_activities_from_instances",
+    "discover_protocol_methods",
+    "temporal_activity_registration",
+    "temporal_workflow_proxy",
+]

--- a/util/temporal/activities.py
+++ b/util/temporal/activities.py
@@ -1,0 +1,130 @@
+"""
+Utilities for working with Temporal activities.
+
+This module provides helper functions for automatically discovering and
+collecting activity methods from decorated instances, eliminating the need
+for manual activity registration boilerplate.
+"""
+
+import inspect
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def discover_protocol_methods(
+    cls_hierarchy: tuple[type, ...],
+) -> dict[str, Any]:
+    """
+    Discover protocol methods that should be wrapped as activities.
+
+    This function finds async methods defined in protocol interfaces within
+    a class hierarchy. It's used to automatically collect methods that should
+    be registered as Temporal activities.
+
+    Args:
+        cls_hierarchy: The class MRO (method resolution order)
+
+    Returns:
+        Dict mapping method names to method objects from the concrete class
+    """
+    methods_to_wrap = {}
+    concrete_class = cls_hierarchy[0]  # The actual class being decorated
+
+    # Look for protocol interfaces (classes with runtime_checkable/Protocol)
+    for base_class in cls_hierarchy:
+        # Skip object base class
+        if base_class is object:
+            continue
+
+        # Check if this is a protocol class
+        has_protocol_attr = hasattr(base_class, "__protocol__")
+        has_is_protocol = getattr(base_class, "_is_protocol", False)
+        has_protocol_in_str = "Protocol" in str(base_class)
+
+        is_protocol = (
+            has_protocol_attr or has_is_protocol or has_protocol_in_str
+        )
+
+        # Only process protocol classes for architectural compliance
+        if is_protocol:
+            # Get method names defined in this class, but get the actual
+            # implementation from the concrete class
+            for name in base_class.__dict__:
+                if name in methods_to_wrap:
+                    continue  # Already found this method
+
+                base_method = getattr(base_class, name)
+                # Only wrap async methods that don't start with underscore
+                if inspect.iscoroutinefunction(
+                    base_method
+                ) and not name.startswith("_"):
+                    # Get the concrete implementation from the actual class
+                    if hasattr(concrete_class, name):
+                        concrete_method = getattr(concrete_class, name)
+                        methods_to_wrap[name] = concrete_method
+
+    # Log final results
+    final_method_names = list(methods_to_wrap.keys())
+    logger.debug(
+        f"Method discovery found {len(methods_to_wrap)}: {final_method_names}"
+    )
+    return methods_to_wrap
+
+
+def collect_activities_from_instances(*instances: Any) -> list[Any]:
+    """Automatically collect all activity methods from decorated instances.
+
+    Uses protocol method discovery to find and collect all methods that have
+    been wrapped as Temporal activities by the @temporal_activity_registration
+    decorator. This ensures we don't miss any activities and eliminates
+    boilerplate registration code.
+
+    Args:
+        *instances: Repository and service instances decorated with
+                   @temporal_activity_registration
+
+    Returns:
+        List of activity methods ready for Worker registration
+
+    Example:
+        # Instead of manually listing all activities:
+        activities = [
+            repo.generate_id,
+            repo.save,
+            repo.get,
+            # ... many more lines
+        ]
+
+        # Use automatic discovery:
+        activities = collect_activities_from_instances(
+            temporal_assembly_repo,
+            temporal_document_repo,
+            temporal_knowledge_service,
+        )
+    """
+    activities = []
+
+    for instance in instances:
+        # Use the same discovery logic as the decorator
+        methods_to_collect = discover_protocol_methods(
+            instance.__class__.__mro__
+        )
+
+        # Get the actual bound methods from the instance
+        for method_name in methods_to_collect:
+            if hasattr(instance, method_name):
+                bound_method = getattr(instance, method_name)
+                activities.append(bound_method)
+                logger.debug(
+                    f"Collected activity method: "
+                    f"{instance.__class__.__name__}.{method_name}"
+                )
+
+    logger.info(
+        f"Collected {len(activities)} activities from "
+        f"{len(instances)} instances"
+    )
+
+    return activities

--- a/util/tests/test_decorators.py
+++ b/util/tests/test_decorators.py
@@ -26,9 +26,9 @@ from pydantic import BaseModel
 from temporalio import activity
 
 # Project imports
-import util.repos.temporal.decorators as decorators_module
+import util.temporal.decorators as decorators_module
 
-from util.repos.temporal.decorators import (
+from util.temporal.decorators import (
     temporal_activity_registration,
     temporal_workflow_proxy,
     _extract_concrete_type_from_base,
@@ -633,12 +633,14 @@ class TestTypeSubstitution:
                 return (T,)
             return get_args(annotation)
 
-        with patch.object(
-            decorators_module, "get_origin", side_effect=mock_get_origin
-        ), patch.object(
-            decorators_module, "get_args", side_effect=mock_get_args
+        with (
+            patch.object(
+                decorators_module, "get_origin", side_effect=mock_get_origin
+            ),
+            patch.object(
+                decorators_module, "get_args", side_effect=mock_get_args
+            ),
         ):
-
             with pytest.raises(TypeError) as exc_info:
                 _substitute_typevar_with_concrete(
                     "FAILING_TYPE", MockAssemblySpecification


### PR DESCRIPTION
Also update to remove the boiler plate, with a new function to give the activity methods.

I'd realised that I'd missed registering the new `get_many` activities in the worker, but rather than just adding them I did a bit of house-keeping and:

1. Added a helper function to list all the activities to be registered (since we already had the code to do this in the decorator module)
2. Moved the temporal decorator module to be in the correct place (since it's no longer just for repos, it's specific to temporal and we use it for services too).