### PR TITLE
Add profiles to compose. Debug and work-around get_many

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   postgres:
+    profiles: ["julee", "calendar", "sample"]
     image: postgres:14-alpine
     environment:
       POSTGRES_USER: temporal
@@ -16,6 +17,7 @@ services:
       retries: 5
 
   calendar-postgres:
+    profiles: ["calendar"]
     image: postgres:14-alpine
     environment:
       POSTGRES_USER: calendar
@@ -33,6 +35,7 @@ services:
       retries: 5
 
   temporal:
+    profiles: ["julee", "calendar", "sample"]
     image: temporalio/auto-setup:1.27.2
     depends_on:
       postgres:
@@ -48,6 +51,7 @@ services:
       - "8233:8233"
 
   temporal-ui:
+    profiles: ["julee", "calendar", "sample"]
     image: temporalio/ui:2.10.3
     depends_on:
       - temporal
@@ -58,6 +62,7 @@ services:
       - "8001:8080"
 
   minio:
+    profiles: ["julee", "calendar", "sample"]
     image: minio/minio:latest
     command: server /data --console-address ":9001"
     environment:
@@ -75,6 +80,7 @@ services:
       retries: 3
 
   sample-worker:
+    profiles: ["sample"]
     build:
       context: .
       dockerfile: sample/Dockerfile.worker
@@ -90,6 +96,7 @@ services:
     restart: on-failure
 
   sample-api:
+    profiles: ["sample"]
     build:
       context: .
       dockerfile: sample/Dockerfile.api
@@ -106,6 +113,7 @@ services:
       - "8002:8000"
 
   calendar-worker:
+    profiles: ["calendar"]
     build:
       context: .
       dockerfile: cal/Dockerfile.worker
@@ -128,6 +136,28 @@ services:
       - ./config:/app/config:ro
       - ./credentials.json:/app/credentials.json:ro
       - ./token.json:/app/token.json:rw
+    restart: on-failure
+    healthcheck:
+      test: ["CMD", "python", "-c", "import temporalio; print('OK')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  julee-worker:
+    profiles: ["julee"]
+    build:
+      context: .
+      dockerfile: julee_example/Dockerfile.worker
+    depends_on:
+      temporal:
+        condition: service_started
+      minio:
+        condition: service_healthy
+    environment:
+      - TEMPORAL_ENDPOINT=temporal:7233
+      - MINIO_ENDPOINT=minio:9000
+      - LOG_LEVEL=INFO
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
     restart: on-failure
     healthcheck:
       test: ["CMD", "python", "-c", "import temporalio; print('OK')"]

--- a/julee_example/Dockerfile.worker
+++ b/julee_example/Dockerfile.worker
@@ -1,0 +1,31 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements and install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the application code
+COPY . .
+
+# Create a non-root user
+RUN useradd --create-home --shell /bin/bash julee
+RUN chown -R julee:julee /app
+USER julee
+
+# Set environment variables
+ENV PYTHONPATH=/app
+ENV PYTHONUNBUFFERED=1
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD python -c "import temporalio; print('OK')"
+
+# Default command - start the julee_example worker
+CMD ["python", "-m", "julee_example.worker"]

--- a/util/validation/__init__.py
+++ b/util/validation/__init__.py
@@ -1,0 +1,21 @@
+"""
+Validation utilities for type checking and debugging serialization issues.
+
+This module provides utilities for validating runtime types against expected
+types, with special focus on debugging common serialization issues in
+Temporal workflows where Pydantic models get deserialized as dictionaries.
+"""
+
+from .type_guards import (
+    TypeValidationError,
+    validate_type,
+    validate_parameter_types,
+    guard_check,
+)
+
+__all__ = [
+    "TypeValidationError",
+    "validate_type",
+    "validate_parameter_types",
+    "guard_check",
+]

--- a/util/validation/type_guards.py
+++ b/util/validation/type_guards.py
@@ -30,8 +30,6 @@ logger = logging.getLogger(__name__)
 class TypeValidationError(TypeError):
     """Raised when type validation fails with detailed diagnostics."""
 
-    pass
-
 
 def validate_type(
     value: Any,
@@ -124,7 +122,7 @@ def _validate_generic_type(
         _validate_list_contents(value, type_args, context_name)
     elif origin_type is dict:
         _validate_dict_contents(value, type_args, context_name)
-    elif origin_type == Union:
+    elif origin_type is Union:
         _validate_union_type(value, type_args, context_name)
 
 
@@ -181,7 +179,10 @@ def _validate_union_type(
     # Try each type in the union
     for union_type in type_args:
         try:
-            validate_type(value, union_type, context_name, allow_none=True)
+            allow_none = union_type is type(None)
+            validate_type(
+                value, union_type, context_name, allow_none=allow_none
+            )
             return  # If any type matches, we're good
         except TypeValidationError:
             continue  # Try the next type

--- a/util/validation/type_guards.py
+++ b/util/validation/type_guards.py
@@ -1,0 +1,381 @@
+"""
+Generic type guard validation system for debugging serialization issues.
+
+This module provides utilities for validating that runtime values match their
+expected types, with detailed diagnostics for common serialization issues
+like Pydantic models being deserialized as dictionaries.
+
+The system can work with any function by introspecting type hints and
+providing clear error messages when types don't match expectations.
+"""
+
+import inspect
+import logging
+from functools import wraps
+from typing import (
+    Any,
+    Dict,
+    List,
+    Union,
+    Callable,
+    get_type_hints,
+    get_origin,
+    get_args,
+)
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+class TypeValidationError(TypeError):
+    """Raised when type validation fails with detailed diagnostics."""
+
+    pass
+
+
+def validate_type(
+    value: Any,
+    expected_type: Any,
+    context_name: str = "value",
+    allow_none: bool = False,
+) -> None:
+    """
+    Validate that a value matches the expected type with detailed diagnostics.
+
+    Args:
+        value: The actual value to validate
+        expected_type: The expected type (from type hints)
+        context_name: Name for error messages (e.g., "parameter 'queries'")
+        allow_none: Whether None values are acceptable
+
+    Raises:
+        TypeValidationError: With detailed diagnosis if type doesn't match
+    """
+    # Handle None values
+    if value is None:
+        if allow_none:
+            return
+        raise TypeValidationError(
+            f"{context_name}: Expected {_format_type(expected_type)}, "
+            f"got None"
+        )
+
+    # Get the origin type for generic types (List[X] -> list, Dict -> dict)
+    origin_type = get_origin(expected_type)
+    type_args = get_args(expected_type)
+
+    # If no origin, it's a simple type
+    if origin_type is None:
+        _validate_simple_type(value, expected_type, context_name)
+    else:
+        _validate_generic_type(
+            value, expected_type, origin_type, type_args, context_name
+        )
+
+
+def _validate_simple_type(
+    value: Any, expected_type: Any, context_name: str
+) -> None:
+    """Validate simple (non-generic) types."""
+    actual_type = type(value)
+
+    # Check if it's the expected type
+    if isinstance(value, expected_type):
+        return
+
+    # Special handling for Pydantic models vs dicts (serialization issue)
+    if (
+        inspect.isclass(expected_type)
+        and issubclass(expected_type, BaseModel)
+        and isinstance(value, dict)
+    ):
+        _raise_pydantic_dict_error(value, expected_type, context_name)
+
+    # Generic type mismatch
+    raise TypeValidationError(
+        f"{context_name}: Type mismatch\n"
+        f"  Expected: {_format_type(expected_type)}\n"
+        f"  Actual: {actual_type.__name__}\n"
+        f"  Value: {_format_value(value)}"
+    )
+
+
+def _validate_generic_type(
+    value: Any,
+    expected_type: Any,
+    origin_type: Any,
+    type_args: tuple,
+    context_name: str,
+) -> None:
+    """Validate generic types like List[X], Dict[K,V], etc."""
+
+    # Check the container type first
+    if not isinstance(value, origin_type):
+        raise TypeValidationError(
+            f"{context_name}: Container type mismatch\n"
+            f"  Expected container: {origin_type.__name__}\n"
+            f"  Actual container: {type(value).__name__}\n"
+            f"  Expected full type: {_format_type(expected_type)}\n"
+            f"  Value: {_format_value(value)}"
+        )
+
+    # Validate contents based on container type
+    if origin_type is list:
+        _validate_list_contents(value, type_args, context_name)
+    elif origin_type is dict:
+        _validate_dict_contents(value, type_args, context_name)
+    elif origin_type == Union:
+        _validate_union_type(value, type_args, context_name)
+
+
+def _validate_list_contents(
+    value: List[Any], type_args: tuple, context_name: str
+) -> None:
+    """Validate contents of a list."""
+    if not type_args:
+        return  # List without type args, can't validate contents
+
+    element_type = type_args[0]
+
+    for i, element in enumerate(value):
+        try:
+            validate_type(element, element_type, f"{context_name}[{i}]")
+        except TypeValidationError as e:
+            # Re-raise with additional context
+            raise TypeValidationError(
+                f"List element validation failed:\n{str(e)}"
+            ) from e
+
+
+def _validate_dict_contents(
+    value: Dict[Any, Any], type_args: tuple, context_name: str
+) -> None:
+    """Validate contents of a dictionary."""
+    if len(type_args) < 2:
+        return  # Dict without full type args, can't validate contents
+
+    key_type, value_type = type_args[0], type_args[1]
+
+    for key, val in value.items():
+        # Validate key type
+        try:
+            validate_type(key, key_type, f"{context_name} key '{key}'")
+        except TypeValidationError as e:
+            raise TypeValidationError(
+                f"Dictionary key validation failed:\n{str(e)}"
+            ) from e
+
+        # Validate value type
+        try:
+            validate_type(val, value_type, f"{context_name}['{key}']")
+        except TypeValidationError as e:
+            raise TypeValidationError(
+                f"Dictionary value validation failed:\n{str(e)}"
+            ) from e
+
+
+def _validate_union_type(
+    value: Any, type_args: tuple, context_name: str
+) -> None:
+    """Validate Union types (including Optional)."""
+    # Try each type in the union
+    for union_type in type_args:
+        try:
+            validate_type(value, union_type, context_name, allow_none=True)
+            return  # If any type matches, we're good
+        except TypeValidationError:
+            continue  # Try the next type
+
+    # None of the union types matched
+    type_names = [_format_type(t) for t in type_args]
+    raise TypeValidationError(
+        f"{context_name}: Value doesn't match any type in Union\n"
+        f"  Expected one of: {', '.join(type_names)}\n"
+        f"  Actual: {type(value).__name__}\n"
+        f"  Value: {_format_value(value)}"
+    )
+
+
+def _raise_pydantic_dict_error(
+    value: dict, expected_type: type, context_name: str
+) -> None:
+    """Raise a detailed error for Pydantic model vs dict issues."""
+    dict_keys = list(value.keys())
+
+    # Try to identify if this looks like a serialized Pydantic model
+    model_fields = []
+    if hasattr(expected_type, "model_fields"):
+        model_fields = list(expected_type.model_fields.keys())
+
+    matching_fields = [k for k in dict_keys if k in model_fields]
+
+    error_msg = (
+        f"SERIALIZATION ISSUE DETECTED: {context_name} is dict instead of "
+        f"{expected_type.__name__}!\n"
+        f"  Expected Type: {expected_type.__name__}\n"
+        f"  Expected Module: {expected_type.__module__}\n"
+        f"  Actual Type: dict\n"
+        f"  Dict Keys: {dict_keys}\n"
+    )
+
+    if model_fields:
+        error_msg += (
+            f"  Expected Model Fields: {model_fields}\n"
+            f"  Matching Fields: {matching_fields}\n"
+            f"  Missing Fields: "
+            f"{[f for f in model_fields if f not in dict_keys]}\n"
+            f"  Extra Fields: "
+            f"{[k for k in dict_keys if k not in model_fields]}\n"
+        )
+
+    error_msg += (
+        f"  Sample Dict Content: {_format_value(value, max_items=3)}\n"
+        f"  This indicates a Temporal/serialization issue where a Pydantic "
+        f"model\n"
+        f"  was serialized correctly but deserialized as a plain "
+        f"dictionary.\n"
+        f"  Check your data converter configuration and type hints."
+    )
+
+    logger.error(
+        "Pydantic serialization issue detected",
+        extra={
+            "context_name": context_name,
+            "expected_type": expected_type.__name__,
+            "expected_module": expected_type.__module__,
+            "actual_type": "dict",
+            "dict_keys": dict_keys,
+            "model_fields": model_fields,
+            "matching_fields": matching_fields,
+            "dict_sample": {k: v for k, v in list(value.items())[:3]},
+        },
+    )
+
+    raise TypeValidationError(error_msg)
+
+
+def _format_type(type_hint: Any) -> str:
+    """Format a type hint for display in error messages."""
+    if hasattr(type_hint, "__name__"):
+        return str(type_hint.__name__)
+    return str(type_hint)
+
+
+def _format_value(value: Any, max_items: int = 5) -> str:
+    """Format a value for display in error messages."""
+    if isinstance(value, dict):
+        if len(value) <= max_items:
+            return str(value)
+        else:
+            items = list(value.items())[:max_items]
+            return f"{dict(items)}... ({len(value)} total items)"
+    elif isinstance(value, (list, tuple)):
+        if len(value) <= max_items:
+            return str(value)
+        else:
+            return f"{value[:max_items]}... ({len(value)} total items)"
+    else:
+        return repr(value)
+
+
+def validate_parameter_types(
+    **expected_types: Any,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """
+    Decorator to validate function parameters against their expected types.
+
+    Usage:
+        @validate_parameter_types(queries=Dict[str, KnowledgeServiceQuery])
+        def my_function(self, queries):
+            # parameters are validated before function runs
+            pass
+
+    Or automatically from type hints:
+        @validate_parameter_types()
+        def my_function(self, queries: Dict[str, KnowledgeServiceQuery]):
+            # type hints are used automatically
+            pass
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            # Get type hints if no explicit types provided
+            types_to_check = expected_types
+            if not types_to_check:
+                try:
+                    types_to_check = get_type_hints(func)
+                except Exception as e:
+                    logger.warning(
+                        f"Could not get type hints for {func.__name__}: {e}"
+                    )
+                    return func(*args, **kwargs)
+
+            # Get parameter names
+            sig = inspect.signature(func)
+            param_names = list(sig.parameters.keys())
+
+            # Validate positional arguments
+            for i, (param_name, arg_value) in enumerate(
+                zip(param_names, args)
+            ):
+                if param_name in types_to_check and param_name != "self":
+                    try:
+                        validate_type(
+                            arg_value,
+                            types_to_check[param_name],
+                            f"parameter '{param_name}'",
+                        )
+                    except TypeValidationError:
+                        logger.error(
+                            f"Parameter validation failed in {func.__name__}",
+                            extra={
+                                "function": func.__name__,
+                                "parameter": param_name,
+                                "parameter_index": i,
+                            },
+                        )
+                        raise
+
+            # Validate keyword arguments
+            for param_name, arg_value in kwargs.items():
+                if param_name in types_to_check:
+                    try:
+                        validate_type(
+                            arg_value,
+                            types_to_check[param_name],
+                            f"parameter '{param_name}'",
+                        )
+                    except TypeValidationError:
+                        logger.error(
+                            f"Parameter validation failed in {func.__name__}",
+                            extra={
+                                "function": func.__name__,
+                                "parameter": param_name,
+                            },
+                        )
+                        raise
+
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def guard_check(
+    value: Any, expected_type: Any, context_name: str = "value"
+) -> None:
+    """
+    Simple guard check function for manual validation.
+
+    Usage:
+        guard_check(queries, Dict[str, KnowledgeServiceQuery], "queries")
+        guard_check(document, Document, "document")
+    """
+    try:
+        validate_type(value, expected_type, context_name)
+        logger.debug(f"Type validation passed for {context_name}")
+    except TypeValidationError:
+        logger.error(f"Guard check failed for {context_name}")
+        raise


### PR DESCRIPTION
Initially this was just adding profiles to the docker compose together with a dockerfile for the worker, so that I could test the julee worker more easily. But the julee worker was erroring.

After too much debugging, it came down to the switch to `get_many` that I'd recently landed - it causes serialization issues with temporal. I didn't want to put more time into investigating it now, so without an issue tracker here, I've left a decent TODO with the details.

This PR also includes a new decorator which helps identify serialization issues with clearer log messages for better debugging (it checks that the input types for activities called from temporal are the expected domain models, not dicts).

So to start the julee example, it's just:

```console
$ docker compose --profile julee up
```

Or to reset (deleting volumes so no stale tasks - helpful when debugging):

```console
$ docker compose --profile julee down -v && docker compose --profile julee up -d
```

With it running, we can trigger an example workflow with:

```console
python -m julee_example.examples.client_example
```

I'm going to follow-up with another PR which deletes the old examples (now that it works with temporal), possibly improve the example for a demo, and eventually add a CI e2e test to ensure it doesn't get broken by another commit (like the switch to get_many did).