### PR TITLE
Small prompt clarification used for demo last week.

### DIFF
--- a/julee_example/examples/data/offensive_language_check.json
+++ b/julee_example/examples/data/offensive_language_check.json
@@ -5,5 +5,5 @@
     "max_tokens": 5,
     "temperature": 0.0
   },
-  "assistant_prompt": "I will analyze the document and respond with only a single number from 0 to 100:"
+  "assistant_prompt": "I have analyzed the document and my single number rating in the range of 0 to 100 is:"
 }

--- a/julee_example/examples/data/professionalism_check.json
+++ b/julee_example/examples/data/professionalism_check.json
@@ -5,5 +5,5 @@
     "max_tokens": 5,
     "temperature": 0.0
   },
-  "assistant_prompt": "I will evaluate the professionalism and respond with only a single number from 0 to 100:"
+  "assistant_prompt": "I have evaluated the professionalism and my single number rating for professionalism in the range of 0 to 100 is:"
 }


### PR DESCRIPTION
While preparing for the demo, I realised the assistant prompts were not worded correctly for continuing to the required result (they used future tense).

Rubber-stamping this 2-liner.