### PR TITLE
Add read-only view for specifications.

### DIFF
--- a/julee_example/README.md
+++ b/julee_example/README.md
@@ -28,15 +28,12 @@ This guide explains how to set up and run the Julee Example application using Do
    - **Web UI**: http://localhost:3000
    - **API**: http://localhost:8000
    - **API Docs**: http://localhost:8000/docs
-   - **Temporal UI**: http://localhost:8001
+   - **Temporal UI**: http://localhost:8001 (linked in the UI)
    - **MinIO Console**: http://localhost:9001
 
 ### Building and Running
 
 ```bash
-# Build and start all services
-docker-compose --profile julee up --build
-
 # Start in background
 docker-compose --profile julee up -d --build
 
@@ -45,20 +42,6 @@ docker-compose --profile julee logs -f
 
 # Stop all services
 docker-compose --profile julee down
-```
-
-### Individual Service Management
-
-```bash
-# Rebuild specific service
-docker-compose build julee-ui
-docker-compose up -d julee-ui
-
-# View logs for specific service
-docker-compose logs -f julee-api
-
-# Restart a service
-docker-compose restart julee-worker
 ```
 
 ## Demo Features
@@ -76,7 +59,29 @@ The application includes pre-loaded demo data:
 2. Click **"Run Assembly"** on the Meeting Minutes specification
 3. Select a document from the dropdown
 4. Click **"Start Assembly"** to trigger the workflow
-5. Monitor progress in the Temporal UI
+5. Monitor progress in the Temporal UI (Click on the Workflows option)
+
+## Current Limitations
+
+### Cannot view assembled document output in UI
+
+The current interface doesn't provide a way to view the final assembled document that results from running the workflow. To view the assembled content, you need to use the API directly with the document ID that's returned when the workflow completes successfully.
+
+**API commands to view assembled document:**
+
+```bash
+# curl command
+curl -X GET "http://localhost:8000/documents/doc-68f2047f-6796-4830-91ad-104da83f6f24/content"
+
+# HTTPie command
+http GET http://localhost:8000/documents/doc-68f2047f-6796-4830-91ad-104da83f6f24/content
+
+# With JSON formatting
+curl -X GET "http://localhost:8000/documents/doc-68f2047f-6796-4830-91ad-104da83f6f24/content" \
+  -H "Accept: application/json" | jq .
+```
+
+Replace the document ID with the one returned from your workflow execution.
 
 ## Troubleshooting
 
@@ -95,21 +100,6 @@ The application includes pre-loaded demo data:
 **Build failures:**
 - Clear Docker cache: `docker system prune -f`
 - Rebuild without cache: `docker-compose build --no-cache`
-
-### Logs and Debugging
-
-```bash
-# View all service logs
-docker-compose --profile julee logs
-
-# Follow specific service logs
-docker-compose logs -f julee-api
-docker-compose logs -f julee-worker
-docker-compose logs -f julee-ui
-
-# Check service health
-docker-compose ps
-```
 
 ### Database and Storage
 

--- a/julee_example/README.md
+++ b/julee_example/README.md
@@ -23,7 +23,7 @@ This guide explains how to set up and run the Julee Example application using Do
 
 2. **Run the application**:
    ```bash
-   docker-compose --profile julee up --build
+   docker-compose --profile julee up --build -d
    ```
 
 3. **Access the services**:

--- a/julee_example/README.md
+++ b/julee_example/README.md
@@ -9,9 +9,11 @@ This guide explains how to set up and run the Julee Example application using Do
 
 ## Quick Start
 
+**Note**: All commands should be run from the top-level `plays_with_temporal` directory.
+
 1. **Set up environment variables**:
    ```bash
-   cp .env.example .env
+   cp julee_example/.env.example .env
    ```
    Edit `.env` and add your API keys:
    ```bash

--- a/julee_example/ui/src/App.tsx
+++ b/julee_example/ui/src/App.tsx
@@ -7,6 +7,7 @@ import CreateQuery from "./pages/CreateQuery";
 import QueryDetail from "./pages/QueryDetail";
 import Specifications from "./pages/Specifications";
 import CreateAssemblySpecification from "./pages/CreateAssemblySpecification";
+import AssemblySpecificationDetail from "./pages/AssemblySpecificationDetail";
 import NotFound from "./pages/NotFound";
 import { Skeleton } from "./components/ui/skeleton";
 
@@ -49,6 +50,10 @@ function App() {
             <Route
               path="/specifications/create"
               element={<CreateAssemblySpecification />}
+            />
+            <Route
+              path="/specifications/:specificationId"
+              element={<AssemblySpecificationDetail />}
             />
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/julee_example/ui/src/components/CustomPropertyViewer.tsx
+++ b/julee_example/ui/src/components/CustomPropertyViewer.tsx
@@ -104,11 +104,6 @@ export default function CustomPropertyViewer({
       : null,
   );
 
-  // Get the full schema for query display
-  const fullSchema = useSelector((state: unknown) =>
-    get((state as any).schemaWizard, ["current", "schema"]),
-  );
-
   // Get field title from schema
   const fieldTitle = schema?.title || "";
 
@@ -119,6 +114,8 @@ export default function CustomPropertyViewer({
     }
 
     try {
+      // 'properties' and 'items' are JSON Schema keywords used to traverse object and array structures.
+      // We filter them out to extract the actual field name, since they do not represent user-defined fields.
       const name = path.findLast(
         (item: string) => item !== "properties" && item !== "items",
       );
@@ -351,8 +348,8 @@ export default function CustomPropertyViewer({
                 Item Type
               </Label>
               <div className="mt-1">
-                <Badge className={getTypeColor(schema.items.type)}>
-                  {schema.items.type}
+                <Badge className={getTypeColor(schema.items.type || "unknown")}>
+                  {schema.items.type || "unknown"}
                 </Badge>
               </div>
             </div>
@@ -385,7 +382,10 @@ export default function CustomPropertyViewer({
                 Properties Count
               </Label>
               <p className="mt-1 text-sm">
-                {Object.keys(schema.properties).length}
+                {typeof schema.properties === "object" &&
+                schema.properties !== null
+                  ? Object.keys(schema.properties).length
+                  : 0}
               </p>
             </div>
             {schema.required && schema.required.length > 0 && (

--- a/julee_example/ui/src/components/CustomPropertyViewer.tsx
+++ b/julee_example/ui/src/components/CustomPropertyViewer.tsx
@@ -1,0 +1,574 @@
+"use client";
+
+import React from "react";
+import { useSelector } from "react-redux";
+import { get } from "lodash-es";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import {
+  FileText,
+  Type,
+  Hash,
+  ToggleLeft,
+  Calendar,
+  List,
+  Settings,
+  Database,
+  Search,
+  ExternalLink,
+} from "lucide-react";
+import { apiClient } from "@/lib/api-client";
+import jsonpointer from "jsonpointer";
+
+interface KnowledgeServiceQuery {
+  query_id: string;
+  name: string;
+  knowledge_service_id: string;
+  prompt: string;
+  assistant_prompt?: string;
+  query_metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+interface QueriesResponse {
+  items: KnowledgeServiceQuery[];
+  total: number;
+  page: number;
+  size: number;
+  pages: number;
+}
+
+interface CustomPropertyViewerProps {
+  knowledgeServiceQueries?: Record<string, string>;
+}
+
+const getTypeIcon = (type: string) => {
+  switch (type) {
+    case "string":
+      return <Type className="h-4 w-4" />;
+    case "number":
+    case "integer":
+      return <Hash className="h-4 w-4" />;
+    case "boolean":
+      return <ToggleLeft className="h-4 w-4" />;
+    case "array":
+      return <List className="h-4 w-4" />;
+    case "object":
+      return <FileText className="h-4 w-4" />;
+    default:
+      return <FileText className="h-4 w-4" />;
+  }
+};
+
+const getTypeColor = (type: string) => {
+  switch (type) {
+    case "string":
+      return "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200";
+    case "number":
+    case "integer":
+      return "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200";
+    case "boolean":
+      return "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200";
+    case "array":
+      return "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200";
+    case "object":
+      return "bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200";
+    default:
+      return "bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200";
+  }
+};
+
+export default function CustomPropertyViewer({
+  knowledgeServiceQueries = {},
+}: CustomPropertyViewerProps) {
+  // Get field information from Redux state (same as CustomPropertyEditor)
+  const path = useSelector(
+    (state: unknown) => (state as any).schemaWizard.field.path,
+  );
+  const uiPath = useSelector(
+    (state: unknown) => (state as any).schemaWizard.field.uiPath,
+  );
+
+  const schema = useSelector((state: unknown) =>
+    path
+      ? get((state as any).schemaWizard, ["current", "schema", ...path])
+      : null,
+  );
+
+  // Get the full schema for query display
+  const fullSchema = useSelector((state: unknown) =>
+    get((state as any).schemaWizard, ["current", "schema"]),
+  );
+
+  // Get field title from schema
+  const fieldTitle = schema?.title || "";
+
+  // Determine field name
+  const fieldName = React.useMemo(() => {
+    if (!path || path.length === 0) {
+      return "root";
+    }
+
+    try {
+      const name = path.findLast(
+        (item: string) => item !== "properties" && item !== "items",
+      );
+      return name || "root";
+    } catch (error) {
+      console.warn("Error computing field name from path:", path, error);
+      return "root";
+    }
+  }, [path]);
+
+  // Create breadcrumb display
+  const renderBreadcrumb = () => {
+    if (!path || path.length === 0) return "Root";
+
+    try {
+      const breadcrumbParts = [];
+      let currentName = "";
+
+      for (const item of path) {
+        if (item === "properties") {
+          breadcrumbParts.push(`{ } ${currentName}`.trim());
+          currentName = "";
+        } else if (item === "items") {
+          breadcrumbParts.push(`[ ] ${currentName}`.trim());
+          currentName = "";
+        } else {
+          currentName = item;
+        }
+      }
+
+      if (currentName) {
+        breadcrumbParts.push(currentName);
+      }
+
+      return breadcrumbParts.join(" → ");
+    } catch (error) {
+      console.warn("Error creating breadcrumb from path:", path, error);
+      return "Root";
+    }
+  };
+
+  // Create JSON pointer path for knowledge service queries (matches KnowledgeServiceSection)
+  const jsonPointerPath = React.useMemo(() => {
+    if (!path || path.length === 0) return "/";
+
+    // Safely join path elements
+    try {
+      const result = "/" + path.join("/");
+      return result;
+    } catch (error) {
+      console.warn("Error creating JSON pointer from path:", path, error);
+      return "/";
+    }
+  }, [path, knowledgeServiceQueries]);
+
+  const queryId =
+    jsonPointerPath && jsonPointerPath !== "/" && path && path.length > 0
+      ? knowledgeServiceQueries[jsonPointerPath]
+      : null;
+
+  // Fetch query details if there's a linked query
+  const { data: queryData } = useQuery({
+    queryKey: ["query", queryId],
+    queryFn: async (): Promise<KnowledgeServiceQuery> => {
+      const response = await apiClient.get(
+        `/knowledge_service_queries/${queryId}`,
+      );
+      return response.data;
+    },
+    enabled: !!queryId,
+    staleTime: 5 * 60 * 1000, // Consider data fresh for 5 minutes
+  });
+
+  if (!path || path.length === 0 || !schema) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Settings className="h-5 w-5" />
+            Property Details
+          </CardTitle>
+          <CardDescription>
+            Select a field from the schema structure to view its properties
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center py-12 text-muted-foreground">
+            <Calendar className="h-16 w-16 mx-auto mb-4 opacity-50" />
+            <p className="text-lg font-medium mb-2">No field selected</p>
+            <p className="text-sm">
+              Click on any field in the schema structure to see its details and
+              query mappings
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          {getTypeIcon(schema.type)}
+          {fieldTitle || fieldName}
+        </CardTitle>
+        <CardDescription className="font-mono text-sm">
+          {renderBreadcrumb()}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Basic Properties */}
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label className="text-sm font-medium text-muted-foreground">
+                Field Name
+              </Label>
+              <p className="mt-1 text-sm font-mono bg-muted px-2 py-1 rounded">
+                {fieldName}
+              </p>
+            </div>
+            <div>
+              <Label className="text-sm font-medium text-muted-foreground">
+                Type
+              </Label>
+              <div className="mt-1">
+                <Badge className={getTypeColor(schema.type)}>
+                  {schema.type}
+                </Badge>
+              </div>
+            </div>
+          </div>
+
+          {fieldTitle && (
+            <div>
+              <Label className="text-sm font-medium text-muted-foreground">
+                Title
+              </Label>
+              <p className="mt-1 text-sm">{fieldTitle}</p>
+            </div>
+          )}
+
+          {schema.description && (
+            <div>
+              <Label className="text-sm font-medium text-muted-foreground">
+                Description
+              </Label>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {schema.description}
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Type-specific Properties */}
+        {schema.type === "string" && (
+          <div className="space-y-4">
+            <h4 className="text-sm font-semibold text-foreground border-b pb-2">
+              String Properties
+            </h4>
+            {schema.minLength !== undefined && (
+              <div>
+                <Label className="text-sm font-medium text-muted-foreground">
+                  Minimum Length
+                </Label>
+                <p className="mt-1 text-sm">{schema.minLength}</p>
+              </div>
+            )}
+            {schema.maxLength !== undefined && (
+              <div>
+                <Label className="text-sm font-medium text-muted-foreground">
+                  Maximum Length
+                </Label>
+                <p className="mt-1 text-sm">{schema.maxLength}</p>
+              </div>
+            )}
+            {schema.pattern && (
+              <div>
+                <Label className="text-sm font-medium text-muted-foreground">
+                  Pattern
+                </Label>
+                <p className="mt-1 text-sm font-mono bg-muted px-2 py-1 rounded">
+                  {schema.pattern}
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {(schema.type === "number" || schema.type === "integer") && (
+          <div className="space-y-4">
+            <h4 className="text-sm font-semibold text-foreground border-b pb-2">
+              Number Properties
+            </h4>
+            {schema.minimum !== undefined && (
+              <div>
+                <Label className="text-sm font-medium text-muted-foreground">
+                  Minimum
+                </Label>
+                <p className="mt-1 text-sm">{schema.minimum}</p>
+              </div>
+            )}
+            {schema.maximum !== undefined && (
+              <div>
+                <Label className="text-sm font-medium text-muted-foreground">
+                  Maximum
+                </Label>
+                <p className="mt-1 text-sm">{schema.maximum}</p>
+              </div>
+            )}
+            {schema.multipleOf !== undefined && (
+              <div>
+                <Label className="text-sm font-medium text-muted-foreground">
+                  Multiple Of
+                </Label>
+                <p className="mt-1 text-sm">{schema.multipleOf}</p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {schema.type === "array" && schema.items && (
+          <div className="space-y-4">
+            <h4 className="text-sm font-semibold text-foreground border-b pb-2">
+              Array Properties
+            </h4>
+            <div>
+              <Label className="text-sm font-medium text-muted-foreground">
+                Item Type
+              </Label>
+              <div className="mt-1">
+                <Badge className={getTypeColor(schema.items.type)}>
+                  {schema.items.type}
+                </Badge>
+              </div>
+            </div>
+            {schema.minItems !== undefined && (
+              <div>
+                <Label className="text-sm font-medium text-muted-foreground">
+                  Minimum Items
+                </Label>
+                <p className="mt-1 text-sm">{schema.minItems}</p>
+              </div>
+            )}
+            {schema.maxItems !== undefined && (
+              <div>
+                <Label className="text-sm font-medium text-muted-foreground">
+                  Maximum Items
+                </Label>
+                <p className="mt-1 text-sm">{schema.maxItems}</p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {schema.type === "object" && schema.properties && (
+          <div className="space-y-4">
+            <h4 className="text-sm font-semibold text-foreground border-b pb-2">
+              Object Properties
+            </h4>
+            <div>
+              <Label className="text-sm font-medium text-muted-foreground">
+                Properties Count
+              </Label>
+              <p className="mt-1 text-sm">
+                {Object.keys(schema.properties).length}
+              </p>
+            </div>
+            {schema.required && schema.required.length > 0 && (
+              <div>
+                <Label className="text-sm font-medium text-muted-foreground">
+                  Required Properties
+                </Label>
+                <div className="mt-1 flex flex-wrap gap-2">
+                  {schema.required.map((prop: string, index: number) => (
+                    <Badge key={index} variant="outline" className="text-xs">
+                      {prop}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {schema.enum && (
+          <div className="space-y-4">
+            <h4 className="text-sm font-semibold text-foreground border-b pb-2">
+              Allowed Values
+            </h4>
+            <div className="flex flex-wrap gap-2">
+              {schema.enum.map((value: any, index: number) => (
+                <Badge key={index} variant="outline" className="text-xs">
+                  {String(value)}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Validation Properties */}
+        {(schema.const !== undefined || schema.default !== undefined) && (
+          <div className="space-y-4">
+            <h4 className="text-sm font-semibold text-foreground border-b pb-2">
+              Validation
+            </h4>
+            {schema.const !== undefined && (
+              <div>
+                <Label className="text-sm font-medium text-muted-foreground">
+                  Constant Value
+                </Label>
+                <p className="mt-1 text-sm font-mono bg-muted px-2 py-1 rounded">
+                  {String(schema.const)}
+                </p>
+              </div>
+            )}
+            {schema.default !== undefined && (
+              <div>
+                <Label className="text-sm font-medium text-muted-foreground">
+                  Default Value
+                </Label>
+                <p className="mt-1 text-sm font-mono bg-muted px-2 py-1 rounded">
+                  {String(schema.default)}
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Knowledge Service Query Mapping */}
+        {queryId && (
+          <Card className="border-l-4 border-l-blue-500">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Search className="h-4 w-4 text-blue-600" />
+                Associated Query
+              </CardTitle>
+              <CardDescription>
+                This field will be populated by data extracted using the linked
+                knowledge service query
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {queryData ? (
+                <div className="space-y-4">
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <Label className="text-sm font-medium text-muted-foreground">
+                        Query Name
+                      </Label>
+                      <p className="mt-1 text-sm font-medium">
+                        {queryData.name}
+                      </p>
+                    </div>
+                    <div>
+                      <Label className="text-sm font-medium text-muted-foreground">
+                        Knowledge Service
+                      </Label>
+                      <p className="mt-1 text-sm">
+                        {queryData.knowledge_service_id}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div>
+                    <Label className="text-sm font-medium text-muted-foreground">
+                      Query ID
+                    </Label>
+                    <div className="mt-1">
+                      <Badge variant="secondary" className="font-mono text-xs">
+                        {queryId}
+                      </Badge>
+                    </div>
+                  </div>
+
+                  <div>
+                    <Label className="text-sm font-medium text-muted-foreground">
+                      Prompt
+                    </Label>
+                    <div className="mt-1 p-3 bg-muted rounded-md">
+                      <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+                        {queryData.prompt}
+                      </p>
+                    </div>
+                  </div>
+
+                  {queryData.assistant_prompt && (
+                    <div>
+                      <Label className="text-sm font-medium text-muted-foreground">
+                        Assistant Prompt
+                      </Label>
+                      <div className="mt-1 p-3 bg-muted rounded-md">
+                        <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+                          {queryData.assistant_prompt}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="pt-2 border-t">
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                      <ExternalLink className="h-3 w-3" />
+                      <span>
+                        Created:{" "}
+                        {new Date(queryData.created_at).toLocaleDateString()}
+                      </span>
+                      <span>•</span>
+                      <span>
+                        Updated:{" "}
+                        {new Date(queryData.updated_at).toLocaleDateString()}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  <div>
+                    <Label className="text-sm font-medium text-muted-foreground">
+                      Query ID
+                    </Label>
+                    <div className="mt-1">
+                      <Badge variant="secondary" className="font-mono text-xs">
+                        {queryId}
+                      </Badge>
+                    </div>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Loading query details...
+                  </p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Raw Properties (for debugging/advanced users) */}
+        {Object.keys(schema).length > 3 && (
+          <details className="space-y-2">
+            <summary className="text-sm font-medium text-muted-foreground cursor-pointer hover:text-foreground">
+              Advanced: Raw Property Definition
+            </summary>
+            <div className="mt-2 bg-muted p-3 rounded-md">
+              <pre className="text-xs overflow-auto">
+                {JSON.stringify(schema, null, 2)}
+              </pre>
+            </div>
+          </details>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/julee_example/ui/src/components/JsonSchemaViewer.css
+++ b/julee_example/ui/src/components/JsonSchemaViewer.css
@@ -1,0 +1,70 @@
+/* JsonSchemaViewer Global Styles */
+
+/* Hide the schema key in read-only mode */
+.formule-schema-key {
+  display: none !important;
+}
+
+/* Hide the entire drop zone container with icon and text */
+.ant-space:has([data-cy="dropArea"]) {
+  display: none !important;
+}
+
+/* Fallback for browsers that don't support :has() */
+[data-cy="dropArea"] {
+  display: none !important;
+}
+
+[data-cy="dropArea"] + .ant-space-item {
+  display: none !important;
+}
+
+/* Hide the parent container by style attributes */
+.ant-space[style*="border: 1px solid lightgrey"] {
+  display: none !important;
+}
+
+/* Hide settings cog icons */
+.ant-btn[title*="settings"],
+.ant-btn[title*="Settings"],
+.anticon-setting {
+  display: none !important;
+}
+
+/* Disable drag functionality but keep click interactions */
+[draggable="true"] {
+  -webkit-user-drag: none !important;
+  -khtml-user-drag: none !important;
+  -moz-user-drag: none !important;
+  -o-user-drag: none !important;
+  user-drag: none !important;
+  cursor: pointer !important;
+}
+
+/* Make clickable items show pointer cursor */
+.formule-field-item,
+.formule-field,
+[role="button"],
+.ant-btn {
+  cursor: pointer !important;
+  pointer-events: auto !important;
+}
+
+/* Allow text selection */
+.ant-typography,
+span {
+  user-select: text !important;
+}
+
+/* Hide field type selector in read-only mode */
+.formule-field-type-selector,
+.ant-select[placeholder*="field type"] {
+  display: none !important;
+}
+
+/* Hide add/remove buttons */
+.ant-btn[title*="add"],
+.ant-btn[title*="remove"],
+.ant-btn[title*="delete"] {
+  display: none !important;
+}

--- a/julee_example/ui/src/components/JsonSchemaViewer.tsx
+++ b/julee_example/ui/src/components/JsonSchemaViewer.tsx
@@ -17,6 +17,7 @@ import {
 } from "react-formule";
 import CustomPropertyViewer from "./CustomPropertyViewer";
 import KnowledgeServiceQueryDisplay from "./KnowledgeServiceQueryDisplay";
+import "./JsonSchemaViewer.css";
 
 interface JsonSchemaViewerProps {
   schema: Record<string, unknown>;
@@ -31,10 +32,6 @@ export default function JsonSchemaViewer({
     return (schema.properties as Record<string, unknown>) || {};
   }, [schema]);
 
-  const requiredFields = useMemo(() => {
-    return (schema.required as string[]) || [];
-  }, [schema]);
-
   const formatJsonSchema = (schema: Record<string, unknown>) => {
     return JSON.stringify(schema, null, 2);
   };
@@ -44,7 +41,7 @@ export default function JsonSchemaViewer({
       // Read-only component - no state changes needed
       if (newState?.schema) {
         try {
-          console.log("Schema viewed:", newState.schema);
+          // Schema viewed - no logging in production
         } catch (err) {
           console.error("Error viewing schema:", err);
         }
@@ -94,66 +91,6 @@ export default function JsonSchemaViewer({
                   },
                 }}
               >
-                <style>{`
-                  /* Hide the schema key in read-only mode */
-                  .formule-schema-key {
-                    display: none !important;
-                  }
-                  /* Hide the entire drop zone container with icon and text */
-                  .ant-space:has([data-cy="dropArea"]) {
-                    display: none !important;
-                  }
-                  /* Fallback for browsers that don't support :has() */
-                  [data-cy="dropArea"] {
-                    display: none !important;
-                  }
-                  [data-cy="dropArea"] + .ant-space-item {
-                    display: none !important;
-                  }
-                  /* Hide the parent container by style attributes */
-                  .ant-space[style*="border: 1px solid lightgrey"] {
-                    display: none !important;
-                  }
-                  /* Hide settings cog icons */
-                  .ant-btn[title*="settings"],
-                  .ant-btn[title*="Settings"],
-                  .anticon-setting {
-                    display: none !important;
-                  }
-                  /* Disable drag functionality but keep click interactions */
-                  [draggable="true"] {
-                    -webkit-user-drag: none !important;
-                    -khtml-user-drag: none !important;
-                    -moz-user-drag: none !important;
-                    -o-user-drag: none !important;
-                    user-drag: none !important;
-                    cursor: pointer !important;
-                  }
-                  /* Make clickable items show pointer cursor */
-                  .formule-field-item,
-                  .formule-field,
-                  [role="button"],
-                  .ant-btn {
-                    cursor: pointer !important;
-                    pointer-events: auto !important;
-                  }
-                  /* Allow text selection */
-                  .ant-typography,
-                  span {
-                    user-select: text !important;
-                  }
-                  /* Hide field type selector in read-only mode */
-                  .formule-field-type-selector,
-                  .ant-select[placeholder*="field type"] {
-                    display: none !important;
-                  }
-                  /* Hide add/remove buttons */
-                  .ant-btn[title*="add"],
-                  .ant-btn[title*="remove"],
-                  .ant-btn[title*="delete"] {
-                    display: none !important;
-                  }
-                `}</style>
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                   <div className="min-h-[400px]">
                     <CustomPropertyViewer

--- a/julee_example/ui/src/components/JsonSchemaViewer.tsx
+++ b/julee_example/ui/src/components/JsonSchemaViewer.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState, useMemo, useCallback, useEffect } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Code2, FileJson } from "lucide-react";
+import {
+  FormuleContext,
+  SchemaPreview,
+  initFormuleSchema,
+} from "react-formule";
+import CustomPropertyViewer from "./CustomPropertyViewer";
+import KnowledgeServiceQueryDisplay from "./KnowledgeServiceQueryDisplay";
+
+interface JsonSchemaViewerProps {
+  schema: Record<string, unknown>;
+  knowledgeServiceQueries?: Record<string, string>;
+}
+
+export default function JsonSchemaViewer({
+  schema,
+  knowledgeServiceQueries = {},
+}: JsonSchemaViewerProps) {
+  const rootProperties = useMemo(() => {
+    return (schema.properties as Record<string, unknown>) || {};
+  }, [schema]);
+
+  const requiredFields = useMemo(() => {
+    return (schema.required as string[]) || [];
+  }, [schema]);
+
+  const formatJsonSchema = (schema: Record<string, unknown>) => {
+    return JSON.stringify(schema, null, 2);
+  };
+
+  const handleFormuleStateChange = useCallback(
+    (newState: { schema?: Record<string, unknown> }) => {
+      // Read-only component - no state changes needed
+      if (newState?.schema) {
+        try {
+          console.log("Schema viewed:", newState.schema);
+        } catch (err) {
+          console.error("Error viewing schema:", err);
+        }
+      }
+    },
+    [],
+  );
+
+  // Initialize the schema in FormuleContext when component mounts
+  useEffect(() => {
+    if (schema && Object.keys(schema).length > 0) {
+      initFormuleSchema({ schema });
+    }
+  }, [schema]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Code2 className="h-5 w-5" />
+          JSON Schema & Query Mappings
+        </CardTitle>
+        <CardDescription>
+          Schema structure and knowledge service query mappings
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <Tabs defaultValue="tree" className="w-full">
+            <TabsList className="grid w-full grid-cols-2">
+              <TabsTrigger value="tree" className="flex items-center gap-2">
+                <FileJson className="h-4 w-4" />
+                Schema Tree
+              </TabsTrigger>
+              <TabsTrigger value="json" className="flex items-center gap-2">
+                <Code2 className="h-4 w-4" />
+                Raw JSON
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="tree" className="mt-4">
+              <FormuleContext
+                synchronizeState={handleFormuleStateChange}
+                theme={{
+                  token: {
+                    colorPrimary: "#3b82f6",
+                  },
+                }}
+              >
+                <style>{`
+                  /* Hide the schema key in read-only mode */
+                  .formule-schema-key {
+                    display: none !important;
+                  }
+                  /* Hide the entire drop zone container with icon and text */
+                  .ant-space:has([data-cy="dropArea"]) {
+                    display: none !important;
+                  }
+                  /* Fallback for browsers that don't support :has() */
+                  [data-cy="dropArea"] {
+                    display: none !important;
+                  }
+                  [data-cy="dropArea"] + .ant-space-item {
+                    display: none !important;
+                  }
+                  /* Hide the parent container by style attributes */
+                  .ant-space[style*="border: 1px solid lightgrey"] {
+                    display: none !important;
+                  }
+                  /* Hide settings cog icons */
+                  .ant-btn[title*="settings"],
+                  .ant-btn[title*="Settings"],
+                  .anticon-setting {
+                    display: none !important;
+                  }
+                  /* Disable drag functionality but keep click interactions */
+                  [draggable="true"] {
+                    -webkit-user-drag: none !important;
+                    -khtml-user-drag: none !important;
+                    -moz-user-drag: none !important;
+                    -o-user-drag: none !important;
+                    user-drag: none !important;
+                    cursor: pointer !important;
+                  }
+                  /* Make clickable items show pointer cursor */
+                  .formule-field-item,
+                  .formule-field,
+                  [role="button"],
+                  .ant-btn {
+                    cursor: pointer !important;
+                    pointer-events: auto !important;
+                  }
+                  /* Allow text selection */
+                  .ant-typography,
+                  span {
+                    user-select: text !important;
+                  }
+                  /* Hide field type selector in read-only mode */
+                  .formule-field-type-selector,
+                  .ant-select[placeholder*="field type"] {
+                    display: none !important;
+                  }
+                  /* Hide add/remove buttons */
+                  .ant-btn[title*="add"],
+                  .ant-btn[title*="remove"],
+                  .ant-btn[title*="delete"] {
+                    display: none !important;
+                  }
+                `}</style>
+                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                  <div className="min-h-[400px]">
+                    <CustomPropertyViewer
+                      knowledgeServiceQueries={knowledgeServiceQueries}
+                    />
+                  </div>
+                  <div className="min-h-[400px] border rounded-lg p-4">
+                    <h3 className="text-sm font-medium mb-3">
+                      Schema Structure
+                    </h3>
+                    <SchemaPreview hideSchemaKey={true} />
+                  </div>
+                </div>
+              </FormuleContext>
+            </TabsContent>
+
+            <TabsContent value="json" className="mt-4">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <Code2 className="h-5 w-5" />
+                    Raw JSON Schema
+                  </CardTitle>
+                  <CardDescription>
+                    The complete JSON schema definition
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="bg-muted p-4 rounded-md overflow-auto max-h-96">
+                    <pre className="text-sm font-mono">
+                      {formatJsonSchema(schema)}
+                    </pre>
+                  </div>
+                </CardContent>
+              </Card>
+            </TabsContent>
+          </Tabs>
+        </div>
+      </CardContent>
+
+      {/* Knowledge Service Queries Overview - Full Width */}
+      <div className="border-t pt-6 px-6 pb-6">
+        <KnowledgeServiceQueryDisplay
+          knowledgeServiceQueries={knowledgeServiceQueries}
+          jsonSchema={schema}
+        />
+      </div>
+    </Card>
+  );
+}

--- a/julee_example/ui/src/components/KnowledgeServiceQueryDisplay.tsx
+++ b/julee_example/ui/src/components/KnowledgeServiceQueryDisplay.tsx
@@ -54,8 +54,12 @@ const getFieldInfo = (jsonPointer: string, schema: Record<string, unknown>) => {
   try {
     const fieldSchema = jsonpointer.get(schema, jsonPointer);
     if (fieldSchema && typeof fieldSchema === "object") {
+      // Extract field name from JSON pointer as fallback
+      const pathParts = jsonPointer.split("/").filter(Boolean);
+      const fieldName = pathParts[pathParts.length - 1] || "field";
+
       return {
-        name: fieldSchema.title || "Untitled Field",
+        name: fieldSchema.title || fieldName,
         description: fieldSchema.description || "No description available",
       };
     }
@@ -66,8 +70,12 @@ const getFieldInfo = (jsonPointer: string, schema: Record<string, unknown>) => {
     );
   }
 
+  // Extract field name from JSON pointer for fallback
+  const pathParts = jsonPointer.split("/").filter(Boolean);
+  const fieldName = pathParts[pathParts.length - 1] || "field";
+
   return {
-    name: `Field at ${jsonPointer}`,
+    name: fieldName,
     description: "Field not found in current schema",
   };
 };

--- a/julee_example/ui/src/pages/AssemblySpecificationDetail.tsx
+++ b/julee_example/ui/src/pages/AssemblySpecificationDetail.tsx
@@ -1,0 +1,396 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useParams, useNavigate } from "react-router-dom";
+import { useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  ArrowLeft,
+  FileText,
+  Settings,
+  Calendar,
+  Clock,
+  AlertCircle,
+  CheckCircle2,
+  Code,
+  Database,
+  Play,
+  Hash,
+  Code2,
+  FileJson,
+} from "lucide-react";
+import { apiClient, getApiErrorMessage } from "@/lib/api-client";
+import WorkflowTriggerModal from "@/components/WorkflowTriggerModal";
+import JsonSchemaViewer from "@/components/JsonSchemaViewer";
+
+interface AssemblySpecification {
+  assembly_specification_id: string;
+  name: string;
+  applicability: string;
+  jsonschema: Record<string, unknown>;
+  status: "active" | "inactive" | "draft" | "deprecated";
+  knowledge_service_queries: Record<string, string>;
+  version: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export default function AssemblySpecificationDetailPage() {
+  const { specificationId } = useParams<{ specificationId: string }>();
+  const navigate = useNavigate();
+  const [showWorkflowModal, setShowWorkflowModal] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  const {
+    data: specification,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ["assembly-specification", specificationId],
+    queryFn: async () => {
+      if (!specificationId) throw new Error("Specification ID is required");
+      const response = await apiClient.get<AssemblySpecification>(
+        `/assembly_specifications/${specificationId}`,
+      );
+      return response.data;
+    },
+    enabled: !!specificationId,
+  });
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  const formatJsonSchema = (schema: Record<string, unknown>) => {
+    return JSON.stringify(schema, null, 2);
+  };
+
+  const handleWorkflowSubmit = async (documentId: string) => {
+    if (!specification) return;
+
+    try {
+      const response = await apiClient.post("/workflows/extract-assemble", {
+        document_id: documentId,
+        assembly_specification_id: specification.assembly_specification_id,
+      });
+
+      setStatusMessage(
+        `Workflow started successfully! Workflow ID: ${response.data.workflow_id}`,
+      );
+      setShowWorkflowModal(false);
+    } catch (error) {
+      console.error("Failed to start workflow:", error);
+      setStatusMessage(
+        `Failed to start workflow: ${getApiErrorMessage(error)}`,
+      );
+      throw error; // Re-throw to let modal handle the error state
+    }
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case "active":
+        return "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200";
+      case "draft":
+        return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200";
+      case "inactive":
+        return "bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200";
+      case "deprecated":
+        return "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200";
+      default:
+        return "bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200";
+    }
+  };
+
+  if (!specificationId) {
+    return (
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <div className="ml-2">
+            <h4 className="font-medium">Invalid Specification ID</h4>
+            <p className="text-sm mt-1">
+              No specification ID provided in the URL.
+            </p>
+          </div>
+        </Alert>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="mb-4">
+          <Button
+            variant="ghost"
+            onClick={() => navigate("/specifications")}
+            className="mb-4"
+          >
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Specifications
+          </Button>
+        </div>
+
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <div className="ml-2">
+            <h4 className="font-medium">Failed to load specification</h4>
+            <p className="text-sm mt-1">{getApiErrorMessage(error)}</p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => refetch()}
+              className="mt-2"
+            >
+              Try Again
+            </Button>
+          </div>
+        </Alert>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="mb-4">
+          <Skeleton className="h-10 w-40" />
+        </div>
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <Skeleton className="h-8 w-3/4" />
+              <Skeleton className="h-4 w-1/2" />
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-3/4" />
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <Skeleton className="h-6 w-1/3" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-48 w-full" />
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  if (!specification) {
+    return (
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="mb-4">
+          <Button
+            variant="ghost"
+            onClick={() => navigate("/specifications")}
+            className="mb-4"
+          >
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Specifications
+          </Button>
+        </div>
+
+        <Alert>
+          <AlertCircle className="h-4 w-4" />
+          <div className="ml-2">
+            <h4 className="font-medium">Specification not found</h4>
+            <p className="text-sm mt-1">
+              The assembly specification with ID "{specificationId}" was not
+              found.
+            </p>
+          </div>
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      {/* Header with back button */}
+      <div className="mb-6">
+        <Button
+          variant="ghost"
+          onClick={() => navigate("/specifications")}
+          className="mb-4"
+        >
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back to Specifications
+        </Button>
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-foreground mb-2">
+              Assembly Specification
+            </h1>
+            <p className="text-muted-foreground">
+              View assembly specification configuration and schema
+            </p>
+          </div>
+          <Button
+            className="flex items-center gap-2"
+            onClick={() => setShowWorkflowModal(true)}
+          >
+            <Play className="h-4 w-4" />
+            Run Assembly
+          </Button>
+        </div>
+      </div>
+
+      {/* Status Message */}
+      {statusMessage && (
+        <Alert className="mb-6 border-green-200 bg-green-50 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-200">
+          <CheckCircle2 className="h-4 w-4" />
+          <AlertDescription>{statusMessage}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="space-y-6">
+        {/* Basic Information */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-start justify-between">
+              <div className="flex-1">
+                <CardTitle className="text-xl mb-2">
+                  {specification.name}
+                </CardTitle>
+                <CardDescription className="text-base">
+                  {specification.applicability}
+                </CardDescription>
+              </div>
+              <div className="flex items-center gap-2 ml-4">
+                <Badge className={getStatusColor(specification.status)}>
+                  {specification.status.charAt(0).toUpperCase() +
+                    specification.status.slice(1)}
+                </Badge>
+                <Badge variant="outline" className="font-mono">
+                  v{specification.version}
+                </Badge>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Calendar className="h-4 w-4" />
+                  <span>Created</span>
+                </div>
+                <p className="text-sm font-medium">
+                  {formatDate(specification.created_at)}
+                </p>
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Clock className="h-4 w-4" />
+                  <span>Last Updated</span>
+                </div>
+                <p className="text-sm font-medium">
+                  {formatDate(specification.updated_at)}
+                </p>
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Hash className="h-4 w-4" />
+                  <span>Version</span>
+                </div>
+                <p className="text-sm font-medium">{specification.version}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* JSON Schema with Visual Viewer */}
+        <JsonSchemaViewer
+          schema={specification.jsonschema}
+          knowledgeServiceQueries={specification.knowledge_service_queries}
+        />
+
+        {/* Technical Details */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Settings className="h-5 w-5" />
+              Technical Details
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <dl className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <dt className="text-sm font-medium text-muted-foreground">
+                  Specification ID
+                </dt>
+                <dd className="mt-1 text-sm font-mono bg-muted px-2 py-1 rounded">
+                  {specification.assembly_specification_id}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-sm font-medium text-muted-foreground">
+                  Status
+                </dt>
+                <dd className="mt-1">
+                  <Badge className={getStatusColor(specification.status)}>
+                    {specification.status.charAt(0).toUpperCase() +
+                      specification.status.slice(1)}
+                  </Badge>
+                </dd>
+              </div>
+              <div>
+                <dt className="text-sm font-medium text-muted-foreground">
+                  Version
+                </dt>
+                <dd className="mt-1 text-sm font-mono bg-muted px-2 py-1 rounded">
+                  {specification.version}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-sm font-medium text-muted-foreground">
+                  Schema Type
+                </dt>
+                <dd className="mt-1 text-sm font-mono bg-muted px-2 py-1 rounded">
+                  {specification.jsonschema?.type || "object"}
+                </dd>
+              </div>
+            </dl>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Workflow Trigger Modal */}
+      {showWorkflowModal && specification && (
+        <WorkflowTriggerModal
+          isOpen={true}
+          onClose={() => setShowWorkflowModal(false)}
+          onSubmit={handleWorkflowSubmit}
+          specification={specification}
+          isSubmitting={false}
+        />
+      )}
+    </div>
+  );
+}

--- a/julee_example/ui/src/pages/AssemblySpecificationDetail.tsx
+++ b/julee_example/ui/src/pages/AssemblySpecificationDetail.tsx
@@ -14,21 +14,16 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
 import {
   ArrowLeft,
-  FileText,
   Settings,
   Calendar,
   Clock,
   AlertCircle,
   CheckCircle2,
-  Code,
-  Database,
   Play,
   Hash,
-  Code2,
-  FileJson,
 } from "lucide-react";
 import { apiClient, getApiErrorMessage } from "@/lib/api-client";
 import WorkflowTriggerModal from "@/components/WorkflowTriggerModal";
@@ -78,10 +73,6 @@ export default function AssemblySpecificationDetailPage() {
       hour: "2-digit",
       minute: "2-digit",
     });
-  };
-
-  const formatJsonSchema = (schema: Record<string, unknown>) => {
-    return JSON.stringify(schema, null, 2);
   };
 
   const handleWorkflowSubmit = async (documentId: string) => {

--- a/julee_example/ui/src/pages/Specifications.tsx
+++ b/julee_example/ui/src/pages/Specifications.tsx
@@ -277,7 +277,10 @@ export default function SpecificationsPage() {
           {specifications.map((spec) => (
             <Card
               key={spec.assembly_specification_id}
-              className="hover:shadow-md transition-shadow"
+              className="hover:shadow-md transition-shadow cursor-pointer"
+              onClick={() => {
+                navigate(`/specifications/${spec.assembly_specification_id}`);
+              }}
             >
               <CardHeader className="pb-3">
                 <div className="flex items-center justify-between">
@@ -323,7 +326,10 @@ export default function SpecificationsPage() {
                 {/* Run Assembly Button */}
                 <div className="mt-4">
                   <Button
-                    onClick={() => handleRunAssembly(spec)}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRunAssembly(spec);
+                    }}
                     disabled={runningWorkflows.has(
                       spec.assembly_specification_id,
                     )}


### PR DESCRIPTION
Follows #99. Ref: https://github.com/gs-gs/pyx-rbtp/issues/85

This PR adds a read-only view for specifications - it's pretty hacky (using the same form views with edit options styled away, while using custom components elsewhere).

<img width="1543" height="1017" alt="image" src="https://github.com/user-attachments/assets/6885729b-35a3-42e5-b1ca-42214eaf563e" />
